### PR TITLE
Snakemake with containerized rules and other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ setup/
 
 # Ignore user R library (created if Azimuth is run)
 R/library/*
+
+# Ignore any in-progess knit.md files
+*.knit.md

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,12 @@ run/
 
 # User files to ignore
 setup/
+
+# Ignore cellranger pipestance files
+*.mro
+
+# Ignore SIF container files
+*.sif
+
+# Ignore user R library (created if Azimuth is run)
+R/library/*

--- a/FinalSnakefile
+++ b/FinalSnakefile
@@ -14,6 +14,7 @@ import subprocess
 import re
 from helper_scripts.sample_list import get_samples
 import shutil
+import time
 
 configfile: 'configs/prelim_configs.yaml'
 configfile: 'configs/post_annotation_configs.yaml'
@@ -417,23 +418,30 @@ if 'qs' not in options and 'rds' in options:
 	final_analyzed_seurat_object = 'data/endpoints/' + PROJECT + '/analysis/RDS/' +  PROJECT + '_final_analyzed_seurat_object.rds'
 
 if 'cloupe' in options:
-	r_comm = "R -q -e 'suppressWarnings(loupeR:::eula_data_dir())'"
-	eula_loc = (subprocess.run(r_comm, shell=True, capture_output=True, text=True)).stdout
-	eula_loc = re.search(r'"\s*([^"]+)\s*"', eula_loc)
-	if not os.path.exists(eula_loc.group(1) + '/eula_agreement'):
-		# print error message with instructions if EULA agreement for loupeR is not present
-		print("You have selected the 'cloupe' option for FINAL_STORAGE in post_annotation_configs.yaml.\n" + 
-			  "The .cloupe file format is part of the loupeR R package from 10x Genomics and\n" +
-			  "requires acceptance of the 10x Genomics loupeR End User License Agreement (EULA).\n")
-		print("Follow the instructions below to accept the loupeR EULA:\n" +
-			  "1. Open an R terminal.\n" +
-			  "2. In R, run the following command:\n" +
-			  "   > suppressWarnings(loupeR::setup())", "\n" +
-			  "3. Accept the agreement.\n" +
-			  "4. Run SWANS again.\n")
-		sys.exit()
-		
+	# print error message with instructions if EULA agreement for loupeR is not present
+	# Trying to make this as obvious as possible! 
+	print(
+		"==============================================================\n" +
+	   	"=========================== ALERT! ===========================\n" +
+		"==============================================================\n" +
+		"==============================================================\n\n" +
+	   	"You have selected the 'cloupe' option for FINAL_STORAGE in post_annotation_configs.yaml.\n" + 
+		"The .cloupe file format is part of the loupeR R package from 10x Genomics and\n" +
+		"requires acceptance of the 10x Genomics loupeR End User License Agreement (EULA).\n"
+	)
+	print(
+		"SWANS implements the LoupeR method for auto-accepting the 10x Genomics loupeR EULA.\n" +
+		"(See https://github.com/10XGenomics/loupeR/blob/d7994c5c5bd1fc7a6202e23f84ecf9df43831e6e/R/eula.R#L85)\n\n" +
+		"If you do not agree to the 10x Genomics LoupeR EULA (https://10xgen.com/EULA),\n" +
+		"EXIT THE PIPELINE NOW and remove 'cloupe' from the DATA_STORAGE options.\n\n" +
+		"==============================================================\n" +
+		"==============================================================\n" +
+		"==============================================================\n" +
+		"==============================================================\n\n"
+	)
 
+	# Add a little time to prevent LoupeR EULA report from passing too quickly.
+	time.sleep(2)
 
 storage_items.append(final_analyzed_seurat_object)
 final_files.append(final_analyzed_seurat_object)

--- a/FinalSnakefile
+++ b/FinalSnakefile
@@ -16,6 +16,7 @@ from helper_scripts.sample_list import get_samples
 import shutil
 import time
 
+container: "docker://migbro/pond:1.1"
 configfile: 'configs/prelim_configs.yaml'
 configfile: 'configs/post_annotation_configs.yaml'
 

--- a/Snakefile
+++ b/Snakefile
@@ -20,7 +20,6 @@ configfile: 'configs/prelim_configs.yaml'
 # set config parameters
 # -------------------------------------------------------------------------
 contact = config['contact']
-print(contact)
 PROJECT = config['PROJECT']
 ORGANISM = config['ORGANISM']
 STARTING_DATA = config['STARTING_DATA']
@@ -92,7 +91,6 @@ if os.path.exists(sample_file) == True:
 # DEFINITIONS/FUNCTIONS ----------------------------------------------------
 # for params with potential for > 1 selection ---------------
 def replace_spaces_commas(config_param_name, config_param):
-	print(config_param_name)
 	normalization_options = ['standard', 'sct']
 	integration_options = ['cca', 'harmony', 'rpca']
 	storage_options = ['qs', 'rds']
@@ -114,7 +112,6 @@ def replace_spaces_commas(config_param_name, config_param):
 		options = config_param.split(',')
 	if ',' not in config_param:
 		options = [config_param]
-		print(type(options))
 
 	if config_param_name == 'RESOLUTION' and ',' not in config_param:
 		return(config_param)
@@ -161,7 +158,6 @@ def replace_spaces_commas(config_param_name, config_param):
 # -----------------------------------------------------------------------------------------
 if VISUALIZATION is not None and type(VISUALIZATION) != 'NoneType' and VISUALIZATION != ' ':
 	VISUALIZATION = replace_spaces_commas('VISUALIZATION', VISUALIZATION)
-	print(VISUALIZATION)
 # -----------------------------------------------------------------------------------------
 
 # check if null ----------------
@@ -171,15 +167,12 @@ def not_null_check_no_yes(config_param, config_param_name):
 	multi_options = ['RESOLUTION', 'SEURAT_NORMALIZATION_METHOD', 'SEURAT_INTEGRATION_METHOD', 'STORAGE']
 	yes_no = ['RUN_SOUPX', 'RUN_DOUBLETFINDER', 'MITO_REGRESSION', 'CELL_CYCLE_REGRESSION', 'REFERENCE_BASED_INTEGRATION', 'RUN_AZIMUTH', 'RUN_TRANSFERDATA', 'TSNE', 'CONSERVED_GENES']
 
-	#print(config_param, config_param_name)
-
 	if config_param is None or type(config_param) == 'NoneType' or config_param == ' ':
 		print(config_param_name + ' cannot be empty.')
 		print('Please write a value for ' + config_param_name + ' in the configs/prelim_configs.yaml file, then run this script again')
 		sys.exit()
 
 	if config_param is not None and config_param != ' ':
-		#print(config_param, config_param_name)
 
 		if config_param_name not in numeric_values:
 			config_param = ''.join(config_param.split()) # remove all spaces
@@ -203,7 +196,6 @@ def not_null_check_no_yes(config_param, config_param_name):
 				config_param = str(config_param)
 
 				if config_param.isdigit() == False:
-					print(config_param_name)
 					print('You must provide a numeric value for ', config_param_name)
 					print('Please write a numeric value (e.g., 12) for this parameter in the configs/prelim_configs.yaml file, then run this script again')
 					sys.exit()
@@ -211,7 +203,6 @@ def not_null_check_no_yes(config_param, config_param_name):
 			if config_param_name == 'RESOLUTION':
 				if str(config_param).isdecimal() == True:
 					config_param = config_param
-					print('single', config_param)
 				if ',' in str(config_param):
 					temp_res = str(config_param).replace(',', '').strip()
 					temp_res = temp_res.replace('.', '')
@@ -222,7 +213,6 @@ def not_null_check_no_yes(config_param, config_param_name):
 						sys.exit()
 
 		if config_param_name in multi_options:
-			print(config_param, config_param_name)
 			config_param = replace_spaces_commas(config_param_name, config_param)
 			
 		return(config_param)
@@ -414,12 +404,10 @@ def user_files(user_file, user_file_name):
 	if user_file is None:
 		user_file = 'does_not_exist'
 
-	print(user_file)
 	return(user_file)
 
 REGRESSION_FILE =  user_files(REGRESSION_FILE, 'REGRESSION_FILE')
 USER_GENE_FILE =  user_files(USER_GENE_FILE, 'USER_GENE_FILE')
-print(USER_GENE_FILE)
 
 if (ORGANISM != 'mouse' and ORGANISM != 'human') or ORGANISM is None:
 	print('This pipeline only works with mouse or human data')
@@ -524,7 +512,6 @@ if RUN_SOUPX == 'y':
 		for item in s:
 			qc_files.append(item)
 			soupX_output.append(item)
-			#print(item)
 # -----------------------------------------------------------------
 
 # -----------------------------------------------------------------

--- a/Snakefile
+++ b/Snakefile
@@ -116,11 +116,9 @@ def replace_spaces_commas(config_param_name, config_param):
 		options = [config_param]
 		print(type(options))
 
-	# added 8.26-----
 	if config_param_name == 'RESOLUTION' and ',' not in config_param:
 		return(config_param)
 	#	flag = 0
-	# added 8.26-----
 
 	for o in options:
 		if config_param_name == 'SEURAT_NORMALIZATION_METHOD':

--- a/Snakefile
+++ b/Snakefile
@@ -14,6 +14,7 @@ from helper_scripts.sample_list import get_samples
 from pathlib import Path 
 import shutil
 
+container: "docker://migbro/pond:1.1"
 configfile: 'configs/prelim_configs.yaml'
 
 # set config parameters
@@ -97,7 +98,7 @@ def replace_spaces_commas(config_param_name, config_param):
 	storage_options = ['qs', 'rds']
 	visualization_options = ['feature', 'violin', 'ridge', 'dot']
 	flag = 1
-
+	
 	if type(config_param) == float:
 		config_param = str(config_param)
 

--- a/helper_scripts/cache.py
+++ b/helper_scripts/cache.py
@@ -11,8 +11,8 @@ def get_config(search_config):
 			if line.startswith(search_config):
 				reference = line.split(search_config)[1].replace('\n', '')
 				reference = reference.replace(':', '').lstrip().rstrip()
-				# if the config is not the RPATH, lower it
-				if not line.startswith('RPATH'):
+				# if the config is not the RPATH or CELLRANGER_REFERENCE, lower it
+				if not line.startswith(('RPATH', 'CELLRANGER_REFERENCE')):
 					reference = reference.lower() # guarantees everything is lowercase
 				#if search_config.startswith('PROJECT'):
 				#	reference = reference.lower()

--- a/helper_scripts/get_sample_paths.py
+++ b/helper_scripts/get_sample_paths.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+def get_sample_paths(sample_list_file):
+    valid_samples = []
+    invalid_samples = []
+
+    with open(sample_list_file) as sample_list:
+        next(sample_list)  # Skip header
+        for line_number, line in enumerate(sample_list, start=2):
+            line = line.strip().split('\t')
+            if len(line) >= 3:
+                sample = line[0].strip()
+                path = line[2].strip()
+
+                if os.path.isdir(path):
+                    print(f"[PASS] Sample '{sample}' ({sample_list_file} line {line_number}): Directory exists -> {path}", file=sys.stderr)
+                    valid_samples.append(path)
+                else:
+                    print(f"[FAIL] Sample '{sample}' ({sample_list_file} line {line_number}): Directory does NOT exist -> {path}", file=sys.stderr)
+                    invalid_samples.append((sample, line_number, path))
+            else:
+                print(f"[ERROR] {sample_list_file} line {line_number}: Incomplete or malformed entry.", file=sys.stderr)
+
+    if invalid_samples:
+        print("\n=== INVALID PATHS DETECTED ===", file=sys.stderr)
+        for sample, line_number, path in invalid_samples:
+            print(f"Sample '{sample}' ({sample_list_file} line {line_number}): Invalid path -> {path}", file=sys.stderr)
+        sys.exit(f"\nExiting: {len(invalid_samples)} invalid path(s) found.")
+
+    # Print comma-sep paths on one line (to stdout)
+    print(",".join(valid_samples))
+
+    return valid_samples
+
+if __name__ == "__main__":
+    get_sample_paths('samples.sample_list')

--- a/run_snakemake.sh
+++ b/run_snakemake.sh
@@ -86,7 +86,9 @@ echo "R_LIBS_USER=$rpath" > .Renviron
 
 # call Snakemake with Singualarity
 #-----------------------------------------------------------------------------
-snakemake --cores $threads --snakefile $SCRIPT_DIR/Snakefile --printshellcmds --use-singularity --singularity-args "-B $sampledir,$cellranger_reference"
+snakemake --cores $threads --snakefile $SCRIPT_DIR/Snakefile --printshellcmds \
+	--use-singularity \
+	--singularity-args "-B $sampledir,$cellranger_reference"
 #-----------------------------------------------------------------------------
 
 # show citations again

--- a/run_snakemake.sh
+++ b/run_snakemake.sh
@@ -1,6 +1,25 @@
 set -e
 
+for arg in "$@"; do
+  case $arg in
+    --sampledir=*)
+      sampledir="${arg#*=}"
+      shift
+      ;;
+    --genomedir=*)
+      genomedir="${arg#*=}"
+      shift
+      ;;
+    *)
+      ;;
+  esac
+done
+
+echo "Sample directory: $sampledir"
+echo "Reference genome directory: $genomedir"
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 # show citations
 #-----------------------------------------------------------------------------
 sh $SCRIPT_DIR/helper_scripts/citations.sh
@@ -62,11 +81,16 @@ rpath=`python3 $SCRIPT_DIR/helper_scripts/cache.py RPATH:` #retrieves rpath name
 echo "R_LIBS_USER=$rpath" > .Renviron
 #-----------------------------------------------------------------------------
 
-# call Snakemake 
+# call Snakemake (sans Singularity)
 #-----------------------------------------------------------------------------
 # snakemake --snakefile Snakefile --printshellcmds --dryrun 
 # snakemake --snakefile Snakefile --printshellcmds --dryrun --rerun-triggers mtime
-snakemake --cores $threads --snakefile $SCRIPT_DIR/Snakefile --printshellcmds 
+# snakemake --cores $threads --snakefile $SCRIPT_DIR/Snakefile
+#-----------------------------------------------------------------------------
+
+# call Snakemake with Singualarity
+#-----------------------------------------------------------------------------
+snakemake --cores $threads --snakefile $SCRIPT_DIR/Snakefile --printshellcmds --use-singularity --singularity-args "-B $sampledir,$genomedir"
 #-----------------------------------------------------------------------------
 
 # show citations again

--- a/run_snakemake.sh
+++ b/run_snakemake.sh
@@ -104,6 +104,7 @@ run_final=`python3 $SCRIPT_DIR/helper_scripts/cache_final.py RUN_FINAL_ANALYSIS:
 if [ -e "$final_config_file" ] && [[ $run_final == "y" ]]; then
 	echo "You have the final config file, let the magic begin"
 	# snakemake --snakefile FinalSnakefile --printshellcmds --dryrun
-	snakemake --cores $threads --snakefile FinalSnakefile --printshellcmds #--forceall 
+	snakemake --cores $threads --snakefile FinalSnakefile --printshellcmds \
+		--use-singularity
 fi
 #-----------------------------------------------------------------------------

--- a/run_snakemake.sh
+++ b/run_snakemake.sh
@@ -6,17 +6,12 @@ for arg in "$@"; do
       sampledir="${arg#*=}"
       shift
       ;;
-    --genomedir=*)
-      genomedir="${arg#*=}"
-      shift
-      ;;
     *)
       ;;
   esac
 done
 
 echo "Sample directory: $sampledir"
-echo "Reference genome directory: $genomedir"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
@@ -67,6 +62,7 @@ path=$path$project
 
 starting_data=`python3 $SCRIPT_DIR/helper_scripts/cache.py STARTING_DATA:` #retrieves starting data from config file
 run_cellranger=`python3 $SCRIPT_DIR/helper_scripts/cache.py RUN_CELLRANGER:` #retrieves starting data from config file
+cellranger_reference=`python3 $SCRIPT_DIR/helper_scripts/cache.py CELLRANGER_REFERENCE:` #retrieves cellranger reference genome from config file
 
 mkdir -p $path
 python3 $SCRIPT_DIR/helper_scripts/setup.py $project $starting_data $run_cellranger #makes project_name/sample_name/[matrix]or[cellranger] for each sample
@@ -90,7 +86,7 @@ echo "R_LIBS_USER=$rpath" > .Renviron
 
 # call Snakemake with Singualarity
 #-----------------------------------------------------------------------------
-snakemake --cores $threads --snakefile $SCRIPT_DIR/Snakefile --printshellcmds --use-singularity --singularity-args "-B $sampledir,$genomedir"
+snakemake --cores $threads --snakefile $SCRIPT_DIR/Snakefile --printshellcmds --use-singularity --singularity-args "-B $sampledir,$cellranger_reference"
 #-----------------------------------------------------------------------------
 
 # show citations again

--- a/src/rmd/final_report.Rmd
+++ b/src/rmd/final_report.Rmd
@@ -571,7 +571,7 @@ if (is.data.frame(final_pathways_adjP)) {
     options = list(
       autoWidth = TRUE,
       dom = 'Blfrtip',
-      buttons = c('colvis', 'copy', 'excel', 'pdf', 'print'), #added comma at end
+      buttons = c('colvis', 'copy', 'excel', 'pdf', 'print'),
       initComplete = JS("
   function() {
     var api = this.api();

--- a/src/rules/analyze_seurat_object.rules
+++ b/src/rules/analyze_seurat_object.rules
@@ -54,7 +54,7 @@ rule analyze_sc_object:
     threads: THREADS
     log:
          log_output = seurat_analysis_log + PROJECT + '_seurat_analysis.log'
-    benchmark: benchmark_log + PROJECT + '_seurat_analysis.benchmark' #added 12.4.2024 ERR
+    benchmark: benchmark_log + PROJECT + '_seurat_analysis.benchmark'
     shell:
         "Rscript \
         {input.script} \

--- a/src/rules/cellranger.rules
+++ b/src/rules/cellranger.rules
@@ -18,7 +18,6 @@ onerror:
 #--------------------RULES---------------------------------------
 rule cellranger_counts:
 	input: 
-		tool = CELLRANGER,
 		fastqs = expand('data/endpoints/' + PROJECT + '/{{s}}/fastq/', s=SAMPLE_LIST)
 	output: 
 		stamp = cellranger_log + PROJECT + '_{s}.stamp',
@@ -29,9 +28,10 @@ rule cellranger_counts:
 	log:
 		log_output = cellranger_log + PROJECT + '_{s}_counts.log'
 	threads: THREADS
-	benchmark: benchmark_log + PROJECT + '_{s}_cellranger_counts.benchmark' #added 12.4.2024 ERR
+	benchmark: benchmark_log + PROJECT + '_{s}_cellranger_counts.benchmark'
+	container: 'docker://beigelk/cellranger:9.0.1'
 	shell:
-		"{input.tool} count --id={wildcards.s} \
+		"cellranger count --id={wildcards.s} \
 		--fastqs={input.fastqs} --output-dir={params.counts} \
 		--sample={wildcards.s} \
 		--transcriptome={params.reference} {params.bam} \

--- a/src/rules/create_images_DGE.rules
+++ b/src/rules/create_images_DGE.rules
@@ -35,7 +35,7 @@ rule cluster_plots_DGE:
 	output: touch_file_create_images_DGE
 	log:
 		log_output = create_images_DGE_log + PROJECT.lower() + '_create_images_DGE.log'
-	benchmark: benchmark_log + PROJECT.lower() + '_cluster_plots.benchmark'  #added 12.4.2024 ERR
+	benchmark: benchmark_log + PROJECT.lower() + '_cluster_plots.benchmark'
 	shell:
 		"Rscript {input.script} \
 			--project {params.project} \

--- a/src/rules/create_initial_seurat.rules
+++ b/src/rules/create_initial_seurat.rules
@@ -35,7 +35,7 @@ rule create_initial_seurat:
         f2 = f2
     log:
         log_output = create_initial_seurat_log + PROJECT + '_create_initial_seurat.log'
-    benchmark: benchmark_log + PROJECT.lower() + '_create_initial_seurat.benchmark'  #added 12.4.2024 ERR
+    benchmark: benchmark_log + PROJECT.lower() + '_create_initial_seurat.benchmark'
     shell:
         "Rscript {input.script} \
         --sample_file {params.sample_file} --project {params.project} --organism {params.organism} \

--- a/src/rules/doubletFinder.rules
+++ b/src/rules/doubletFinder.rules
@@ -32,7 +32,7 @@ rule doubletFinder:
   threads: 2
   log:
     log_output = doubletFinder_log + PROJECT + '_{s}_doubletFinder.log'
-  benchmark: benchmark_log + PROJECT.lower() + '_{s}_doubletFinder.benchmark'  #added 12.4.2024 ERR
+  benchmark: benchmark_log + PROJECT.lower() + '_{s}_doubletFinder.benchmark'
   shell:
     "Rscript \
     {input.script} \

--- a/src/rules/final_analysis.rules
+++ b/src/rules/final_analysis.rules
@@ -45,7 +45,7 @@ rule final_analysis:
 	output: 
 		storage_files = storage_items,
 		seurat_object = final_analyzed_seurat_object,
-	benchmark: benchmark_log + PROJECT + '_final_analysis.benchmark' #added 12.4.2024 ERR
+	benchmark: benchmark_log + PROJECT + '_final_analysis.benchmark'
 	log:
 		log_output = final_log + PROJECT + '_final_analysis.log'
 	#resources:
@@ -81,7 +81,7 @@ rule trajectory_analysis:
 	output: touch_trajectory_file
 	log:
 		log_output = final_log + PROJECT.lower() + '_trajectory_analysis.log'
-	benchmark: benchmark_log + PROJECT.lower() + '_trajectory_analysis.benchmark' #added 12.4.2024 ERR
+	benchmark: benchmark_log + PROJECT.lower() + '_trajectory_analysis.benchmark'
 	shell:
 		"Rscript {input.script} \
 			{params.project} {input.seurat_object} {params.celltype_assignment_file} \

--- a/src/rules/get_memory.rules
+++ b/src/rules/get_memory.rules
@@ -21,7 +21,7 @@ rule memory:
 		m_file = memory_file
 	log:
 		log_output = memory_log + PROJECT + '_memory.log'
-	benchmark: benchmark_log + PROJECT.lower() + '_memory.benchmark'  #added 12.4.2024 ERR
+	benchmark: benchmark_log + PROJECT.lower() + '_memory.benchmark'
 	shell:
 		"cells=$( zcat {params.barcodes_files} | wc -l) && \
 			genes=$( zcat {params.features_files} | wc -l) && \

--- a/src/rules/multiQC.rules
+++ b/src/rules/multiQC.rules
@@ -25,7 +25,7 @@ rule multiqc_cellranger_report:
 		title = PROJECT + 'Cell Ranger Summary',
 	log:
 		log_output = multiqc_log + 'multiqc_cellranger_report.log'
-	benchmark: benchmark_log + PROJECT.lower() + '_multiqc_cellranger.benchmark'  #added 12.4.2024 ERR
+	benchmark: benchmark_log + PROJECT.lower() + '_multiqc_cellranger.benchmark'
 	shell:
 		"multiqc {params.search_dir} -m {params.module} \
 			 --filename {params.report_name} -o {params.outdir} \

--- a/src/rules/multiQC.rules
+++ b/src/rules/multiQC.rules
@@ -15,7 +15,6 @@ onerror:
 #--------------------RULES---------------------------------------
 rule multiqc_cellranger_report:
 	input: 
-		tool = MULTIQC,
 		input_data = qc_cellranger
 	output: cellranger_report
 	params:
@@ -28,6 +27,6 @@ rule multiqc_cellranger_report:
 		log_output = multiqc_log + 'multiqc_cellranger_report.log'
 	benchmark: benchmark_log + PROJECT.lower() + '_multiqc_cellranger.benchmark'  #added 12.4.2024 ERR
 	shell:
-		"{input.tool} {params.search_dir} -m {params.module} \
+		"multiqc {params.search_dir} -m {params.module} \
 			 --filename {params.report_name} -o {params.outdir} \
 			 --verbose --force 2> {log.log_output}" 

--- a/src/rules/soupX.rules
+++ b/src/rules/soupX.rules
@@ -29,7 +29,7 @@ rule soupX:
 		matrix_path = 'data/endpoints/' + PROJECT + '/' + '{s}/soupX/matrix.mtx.gz',
 	log:
 		log_output = soupX_log  + PROJECT + '_{s}_soupX.log'
-	benchmark: benchmark_log + PROJECT.lower() + '_{s}_soupX.benchmark' #added 12.4.2024 ERR
+	benchmark: benchmark_log + PROJECT.lower() + '_{s}_soupX.benchmark'
 	shell:
 		"Rscript {input.script} \
 		--sample {params.sample} \

--- a/src/scripts/analyze_seurat_object.R
+++ b/src/scripts/analyze_seurat_object.R
@@ -752,8 +752,6 @@ if (tolower(organism) == 'mouse') {
 # GET A VECTOR OF THE REGRESSION VARIABLES TO USE IN DATA SCALING + ADD USER-SUPPLIED REGRESSION VARS
 regression_vars = get_regression_variables(cc_regression, cc_method, mito_regression, ribo_regression, regression_file)
 
-print(regression_vars)
-
 # GET SCORING
 S = get_scoring(S, s_genes, g2m_genes, regression_vars, regression_file)
 

--- a/src/scripts/create_images_DGE.R
+++ b/src/scripts/create_images_DGE.R
@@ -79,7 +79,7 @@ suppressPackageStartupMessages(library(qs, lib.loc=lib_path))
 suppressPackageStartupMessages(library(future, lib.loc=lib_path))
 suppressPackageStartupMessages(library(progressr, lib.loc=lib_path))
 suppressPackageStartupMessages(library(presto, lib.loc=lib_path))
-suppressPackageStartupMessages(library(tidyverse, lib.loc=lib_path)) #added 12.3.24 ERR
+suppressPackageStartupMessages(library(tidyverse, lib.loc=lib_path))
 
 # PARALLEL w/ FUTURE + SET SEED
 #--------------------------------------------------------------------
@@ -220,14 +220,13 @@ proportions_UMAP_DGE <- function(seurat_object, num_samples, visi, genes=genes, 
         z_ae <- reshape2::melt(z_ae)
         z_ae$variable <- gsub('g', '', z_ae$variable)
         colnames(z_ae) <- c('gene', 'cluster', 'z.score') # changed to z.score 2.25.25
-        z_ae$z.score <- round(z_ae$z.score, 3) # added 2.25.25
+        z_ae$z.score <- round(z_ae$z.score, 3)
 
         z_scores_report = paste(report_table_path, '/', project, '_z_scores.', name, '.txt', sep='')
         write.table(z_ae, file=z_scores_report, sep='\t', quote=F, col.names=TRUE, row.names=FALSE)
         # ---------------------------------------------------------
 
 				# phase information ---------------------------------------
-				# added 9.2.2025
 				# Experiment
 				print('making table of phases across all clusters (by experiment)...')
 				cc_phase_cluster <- as.data.frame(table(seurat_object@meta.data$Experiment, seurat_object@meta.data[[name]], seurat_object@meta.data$Phase))
@@ -265,16 +264,13 @@ proportions_UMAP_DGE <- function(seurat_object, num_samples, visi, genes=genes, 
 				print(DimPlot(seurat_object, group.by = name, reduction = redux_umap, split.by = 'Experiment', repel=TRUE, label=TRUE)) + NoLegend()
 				print(DimPlot(seurat_object, group.by = name, reduction = redux_umap, split.by = 'Sample', repel=TRUE, label=TRUE)) + NoLegend()
 				print(DimPlot(seurat_object, reduction = redux_umap, group.by = 'Phase'))
-				# added september 25
 				print(DimPlot(seurat_object, reduction = redux_umap, group.by = 'Phase', split.by='Experiment'))
 				print(DimPlot(seurat_object, reduction = redux_umap, group.by = 'Phase', split.by='Sample'))
 
-				# added geompoint plots 9.2.2025
 				print(ggplot(cc_phase_cluster_sample, aes(x=Cluster, y=Frequency, shape=Phase, color=Sample)) + 
 				  geom_point(size=3) + theme_minimal() + theme(axis.text.x = element_text(angle = 45, hjust = 1)) +
 				  labs(x='Cluster', y='Frequency', shape='Cell Cycle Phase', color='Sample'))
 
-				# added geompoint plots 9.2.2025
 				print(ggplot(cc_phase_cluster, aes(x=Cluster, y=Frequency, shape=Phase, color=Experiment)) + 
 				  geom_point(size=3) + theme_minimal() + theme(axis.text.x = element_text(angle = 45, hjust = 1)) +
 				  labs(x='Cluster', y='Frequency', shape='Cell Cycle Phase', color='Experiment'))
@@ -488,7 +484,6 @@ proportions_UMAP_DGE <- function(seurat_object, num_samples, visi, genes=genes, 
             count <- as.numeric(count)
             print(count)
 
-            # added 1.17.25 ERR
             # Need to check that at least 3 cells exist in one experimental group to prevent failure
             cluster_subset <- subset(seurat_object, idents = count)
             cells_per_condition <- table(cluster_subset@meta.data$Experiment)

--- a/src/scripts/doubletFinder.R
+++ b/src/scripts/doubletFinder.R
@@ -281,7 +281,7 @@ write_doublet_ids <- function(seurat.object, sample, project)
   # define it as a Doublet in the final Doublet_Classification
   doublet.class = seurat.object@meta.data[, doublet.col.list] %>%
     mutate(DF_Classification = case_when(
-		if_any(all_of(doublet.col.list), ~ .x == 'Doublet') ~ 'Doublet',  TRUE ~ 'Singlet')  # Check across columns # added 3.4.25
+		if_any(all_of(doublet.col.list), ~ .x == 'Doublet') ~ 'Doublet',  TRUE ~ 'Singlet')  # Check across columns
       #if_any(c(doublet.col.list), ~ .x == 'Doublet') ~ 'Doublet', .default = 'Singlet')
     )
   

--- a/src/scripts/final_analysis.R
+++ b/src/scripts/final_analysis.R
@@ -140,7 +140,6 @@ if ('cloupe' %in% unlist(final_storage_method)) {
 
 	# Set the EULA auto accept env var to "y"
 	Sys.setenv(AUTO_ACCEPT_EULA = "y")
-	# AUTO_ACCEPT_ENV_VAR = 'y'
 
 	# Assign env var to another env var to comply with:
 	# https://github.com/10XGenomics/loupeR/blob/d7994c5c5bd1fc7a6202e23f84ecf9df43831e6e/R/eula.R
@@ -148,6 +147,7 @@ if ('cloupe' %in% unlist(final_storage_method)) {
 
 	# Run the loupeR:::eula() function which will check AUTO_ACCEPT_ENV_VAR with auto_accepted_eula()
 	loupeR:::eula()
+	loupeR::setup()
 }
 # --------------------------------------------------------------------
 

--- a/src/scripts/final_analysis.R
+++ b/src/scripts/final_analysis.R
@@ -129,6 +129,13 @@ if (is.null(final_storage) == FALSE)
 # AUTOACCEPT THE LOUPER EULA
 # --------------------------------------------------------------------
 if ('cloupe' %in% unlist(final_storage_method)) {
+
+	options(
+		repos = c(CRAN = "internalrepo"),
+		download.file.method = "curl",
+		download.file.extra = "-k -L")
+
+	# Load library	
 	library(loupeR)
 
 	# Set the EULA auto accept env var to "y"

--- a/src/scripts/final_analysis.R
+++ b/src/scripts/final_analysis.R
@@ -126,6 +126,24 @@ if (is.null(final_storage) == FALSE)
 }
 # --------------------------------------------------------------------
 
+# AUTOACCEPT THE LOUPER EULA
+# --------------------------------------------------------------------
+if ('cloupe' %in% unlist(final_storage_method)) {
+	library(loupeR)
+
+	# Set the EULA auto accept env var to "y"
+	Sys.setenv(AUTO_ACCEPT_EULA = "y")
+	# AUTO_ACCEPT_ENV_VAR = 'y'
+
+	# Assign env var to another env var to comply with:
+	# https://github.com/10XGenomics/loupeR/blob/d7994c5c5bd1fc7a6202e23f84ecf9df43831e6e/R/eula.R
+	AUTO_ACCEPT_ENV_VAR = "AUTO_ACCEPT_EULA"
+
+	# Run the loupeR:::eula() function which will check AUTO_ACCEPT_ENV_VAR with auto_accepted_eula()
+	loupeR:::eula()
+}
+# --------------------------------------------------------------------
+
 # IMPORT LIBS
 #--------------------------------------------------------------------
 suppressPackageStartupMessages(library(Seurat, lib.loc=lib_path))

--- a/src/scripts/final_analysis.R
+++ b/src/scripts/final_analysis.R
@@ -317,7 +317,7 @@ rename_and_visualize <- function(seurat_object, celltype_file, ident, genes, mar
 	print('...by experiment...')
 	#-----------------------------------------------------------
 
-	# add in totals (w/ + without %)  #added 12.4.2024 ERR
+	# add in totals (w/ + without %)
 	number_perCluster_experiment <- table(seurat_object@meta.data$Experiment, seurat_object@meta.data[['celltypes']])
 	number_perCluster_experiment_prop <- round(proportions(as.matrix(number_perCluster_experiment), 1), 3)
 


### PR DESCRIPTION
- Specifying the container to be used ("docker://migbro/pond:1.1") universally unless otherwise specified
- Adding items to gitignore
- Automating loupeR EULA acceptance, with added warning to user; also adding `loupeR::setup()` to download loupeR exe
- Updating `run_snakemake.sh` with arguments needed for running Snakemake with Singularity
- `rule cellranger_counts` has its own container for just cellranger ("docker://beigelk/cellranger:9.0.1")
- Cleaning up old comments and notes
- In `run_snakemake.sh`, get genome reference path from `prelim_configs.yaml` for Singularity bind mount
- In `run_snakemake.sh`, get sample directory paths with new `helper_script/get_sample_paths.py` for Singularity bind mounts