### PR TITLE
Adding all paths from config files as Singularity bind mounts

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -14,7 +14,7 @@ from helper_scripts.sample_list import get_samples
 from pathlib import Path 
 import shutil
 
-container: "docker://migbro/pond:1.1"
+container: "docker://beigelk/pond:1.2"
 configfile: 'configs/prelim_configs.yaml'
 
 # set config parameters

--- a/configs/example_prelim_configs.yaml
+++ b/configs/example_prelim_configs.yaml
@@ -11,10 +11,10 @@ ORGANISM: human
 STARTING_DATA: cellranger
 
 # run Cell Ranger count pipeline (y/n)
-RUN_CELLRANGER: y
+RUN_CELLRANGER: n
 
 # path to the genome to use in cellranger
-CELLRANGER_REFERENCE: /reference_genome/
+CELLRANGER_REFERENCE:
 
 # run multiQC on Cell Ranger output (y/n) -- must have outs/summary.html 
 RUN_MULTIQC: n

--- a/helper_scripts/cache.py
+++ b/helper_scripts/cache.py
@@ -5,17 +5,25 @@ reference_type, reference = '', ''
 config = sys.argv[1]
 
 def get_config(search_config):
+
+	# configs to exclude from lowercasing
+	exclusion_list = (
+		'RPATH',
+		'CELLRANGER_REFERENCE',
+		'TRANSFERDATA_REF_FILE',
+		'REGRESSION_FILE',
+		'USER_GENE_FILE',
+	)
+
 	with open('configs/prelim_configs.yaml') as input_file:
 		for line in input_file.readlines():
 			line = line.lstrip()
 			if line.startswith(search_config):
 				reference = line.split(search_config)[1].replace('\n', '')
 				reference = reference.replace(':', '').lstrip().rstrip()
-				# if the config is not the RPATH or CELLRANGER_REFERENCE, lower it
-				if not line.startswith(('RPATH', 'CELLRANGER_REFERENCE', 'TRANSFERDATA_REF_FILE')):
-					reference = reference.lower() # guarantees everything is lowercase
-				#if search_config.startswith('PROJECT'):
-				#	reference = reference.lower()
+				# if the config is not in the exclusion_list, lowercase it
+				if not line.startswith(exclusion_list):
+					reference = reference.lower() 
 	return(reference)
 
 selection = get_config(config)

--- a/helper_scripts/cache_final.py
+++ b/helper_scripts/cache_final.py
@@ -5,15 +5,23 @@ reference_type, reference = '', ''
 config = sys.argv[1]
 
 def get_config(search_config):
+
+	# configs to exclude from lowercasing
+	exclusion_list = (
+		'CLUSTER_ANNOTATION_FILE',
+		'USER_ANALYZED_SEURAT_OBJECT',
+		'FINAL_USER_GENE_FILE'
+	)
+
 	with open('configs/post_annotation_configs.yaml') as input_file:
 		for line in input_file.readlines():
 			line = line.lstrip()
 			if line.startswith(search_config):
 				reference = line.split(search_config)[1].replace('\n', '')
 				reference = reference.replace(':', '').lstrip().rstrip()
-				reference = reference.lower() # guarantees everything is lowercase
-				#if search_config.startswith('PROJECT'):
-				#	reference = reference.lower()
+				# if the config is not in the exclusion_list, lowercase it
+				if not line.startswith(exclusion_list):
+					reference = reference.lower() 
 	return(reference)
 
 selection = get_config(config)

--- a/run_snakemake.sh
+++ b/run_snakemake.sh
@@ -114,8 +114,8 @@ for config in "${prelim_file_configs[@]}"; do
 done
 echo -e "===================================================================================\n\n"
 
-# Remove duplicates
 echo -e "================= Singularity bind mounts for preliminary analysis ================="
+# Remove duplicates
 prelim_bind_mnts=$(echo "$prelim_bind_mnts" | tr ',' '\n' | awk '!seen[$0]++' | paste -sd ',' -)
 echo -e "$prelim_bind_mnts"
 echo -e "====================================================================================\n\n\n"
@@ -181,8 +181,8 @@ if [ -e "$final_config_file" ] && [[ $run_final == "y" ]]; then
 	done
 	echo -e "=======================================================================================\n\n"
 
-	# Remove duplicates
 	echo -e "============== Singularity bind mount list for post-annotation analysis ==============="
+	# Remove duplicates
 	postanno_bind_mnts=$(echo "$postanno_bind_mnts" | tr ',' '\n' | awk '!seen[$0]++' | paste -sd ',' -)
 	echo -e "$postanno_bind_mnts"
 	echo -e "=======================================================================================\n\n\n"

--- a/run_snakemake.sh
+++ b/run_snakemake.sh
@@ -73,20 +73,23 @@ sample_bind_mnts=$(python3 $SCRIPT_DIR/helper_scripts/get_sample_paths.py)
 prelim_bind_mnts+="$sample_bind_mnts"
 echo -e "===================================================================================\n\n"
 
-echo -e "========== CELLRANGER_REFERENCE directory for Singularity bind mounting ==========="
 # Gets cellranger reference genome dir from config file, checks existtence, adds as bind mount
 if [ "$run_cellranger" = "y" ]; then
+echo -e "========== CELLRANGER_REFERENCE directory for Singularity bind mounting ==========="
 	cellranger_reference=`python3 $SCRIPT_DIR/helper_scripts/cache.py CELLRANGER_REFERENCE:`
-	if [[ -n "$cellranger_reference" && -d "$cellranger_reference" ]]; then
-		echo -e "[PASS] CELLRANGER_REFERENCE path exists, directory will be bound -> $cellranger_reference"
-		prelim_bind_mnts+=",$cellranger_reference"
-	else
-		echo -e "[WARN] CELLRANGER_REFERENCE path DOES NOT EXIST -> $cellranger_reference"
-	fi
-	else
+
+	if [[ -z "$cellranger_reference" ]]; then
 		echo -e "[WARN] No directory path entered for CELLRANGER_REFERENCE"
-fi
+	else
+		if [[ -n "$cellranger_reference" && -d "$cellranger_reference" ]]; then
+			echo -e "[PASS] CELLRANGER_REFERENCE directory exists, directory will be bound -> $cellranger_reference"
+			prelim_bind_mnts+=",$cellranger_reference"
+		else
+			echo -e "[WARN] CELLRANGER_REFERENCE directory DOES NOT EXIST -> $cellranger_reference"
+		fi
+	fi
 echo -e "===================================================================================\n\n"
+fi
 
 echo -e "============= Preliminary analysis files for Singularity bind mounts =============="
 # Check that any files in the prelim_configs.yaml exists, gets their directory for bind mounting
@@ -98,19 +101,19 @@ for config in "${prelim_file_configs[@]}"; do
 	if [[ -z "$file_path" ]]; then
   		echo -e "[WARN] No file path entered for $config"
   		continue
-	fi
-
-	# Get the absolute directory path of that file
-	dir=$(realpath "$(dirname "$file_path")")
-
-	# Check dir exsists
-	if [[ -n "$dir" && -d "$dir" ]]; then
-		[[ -n "$prelim_bind_mnts" ]] && prelim_bind_mnts+=","
-		prelim_bind_mnts+="$dir"
-		echo -e "[PASS] File exists for $config: $file_path, directory will be bound -> $dir"
 	else
-    	echo -e "Warning: Directory for $config does not exist: $config -> $dir"
-  	fi
+		# Get the absolute directory path of that file
+		dir=$(realpath "$(dirname "$file_path")")
+
+		# Check dir exsists
+		if [[ -n "$dir" && -d "$dir" ]]; then
+			[[ -n "$prelim_bind_mnts" ]] && prelim_bind_mnts+=","
+			prelim_bind_mnts+="$dir"
+			echo -e "[PASS] File exists for $config: $file_path, directory will be bound -> $dir"
+		else
+    		echo -e "Warning: Directory for $config does not exist: $config -> $dir"
+  		fi
+	fi
 done
 echo -e "===================================================================================\n\n"
 
@@ -165,18 +168,18 @@ if [ -e "$final_config_file" ] && [[ $run_final == "y" ]]; then
 		if [[ -z "$file_path" ]]; then
 			echo "[WARN] No file path entered for $config"
 			continue
-		fi
-
-		# Get the absolute directory path of that file
-		dir=$(realpath "$(dirname "$file_path")")
-
-		# Check dir exsists
-		if [[ -n "$dir" && -d "$dir" ]]; then
-			[[ -n "$postanno_bind_mnts" ]] && postanno_bind_mnts+=","
-			postanno_bind_mnts+="$dir"
-			echo "[PASS] File exists for $config: $file_path, directory will be bound -> $dir"
 		else
-			echo "Warning: Directory for $config does not exist: $config -> $dir"
+			# Get the absolute directory path of that file
+			dir=$(realpath "$(dirname "$file_path")")
+
+			# Check dir exsists
+			if [[ -n "$dir" && -d "$dir" ]]; then
+				[[ -n "$postanno_bind_mnts" ]] && postanno_bind_mnts+=","
+				postanno_bind_mnts+="$dir"
+				echo "[PASS] File exists for $config: $file_path, directory will be bound -> $dir"
+			else
+				echo "Warning: Directory for $config does not exist: $config -> $dir"
+			fi
 		fi
 	done
 	echo -e "=======================================================================================\n\n"

--- a/run_snakemake.sh
+++ b/run_snakemake.sh
@@ -48,8 +48,7 @@ echo "Creating project directory (if it does not exist)"
 path=$path$project
 
 starting_data=`python3 $SCRIPT_DIR/helper_scripts/cache.py STARTING_DATA:` #retrieves starting data from config file
-run_cellranger=`python3 $SCRIPT_DIR/helper_scripts/cache.py RUN_CELLRANGER:` #retrieves starting data from config file
-run_transferdata=`python3 $SCRIPT_DIR/helper_scripts/cache.py RUN_TRANSFERDATA:`
+run_cellranger=`python3 $SCRIPT_DIR/helper_scripts/cache.py RUN_CELLRANGER:` #retrieves cellranger y/n from config file
 
 mkdir -p $path
 python3 $SCRIPT_DIR/helper_scripts/setup.py $project $starting_data $run_cellranger #makes project_name/sample_name/[matrix]or[cellranger] for each sample
@@ -64,29 +63,62 @@ rpath=`python3 $SCRIPT_DIR/helper_scripts/cache.py RPATH:` #retrieves rpath name
 echo "R_LIBS_USER=$rpath" > .Renviron
 #-----------------------------------------------------------------------------
 
-# Get paths for Singularity bind mounts
+# Get paths for Singularity bind mounts (preliminary analysis)
 #-----------------------------------------------------------------------------
-## Retrieves cellranger reference genome dir from config file
+prelim_bind_mnts=""
+
+# Gets paths from sample file to use as bind mounts to access sample data
+echo -e "\n\n============= Sample file directories for Singularity bind mounts ============="
+sample_bind_mnts=$(python3 $SCRIPT_DIR/helper_scripts/get_sample_paths.py)
+prelim_bind_mnts+="$sample_bind_mnts"
+echo -e "===================================================================================\n\n"
+
+echo -e "========== CELLRANGER_REFERENCE directory for Singularity bind mounting ==========="
+# Gets cellranger reference genome dir from config file, checks existtence, adds as bind mount
 if [ "$run_cellranger" = "y" ]; then
 	cellranger_reference=`python3 $SCRIPT_DIR/helper_scripts/cache.py CELLRANGER_REFERENCE:`
-	echo -e "\nReference genome directory bind mount for Singularity: $cellranger_reference\n"
-else
-	cellranger_reference=''
+	if [[ -n "$cellranger_reference" && -d "$cellranger_reference" ]]; then
+		echo -e "[PASS] CELLRANGER_REFERENCE path exists, directory will be bound -> $cellranger_reference"
+		prelim_bind_mnts+=",$cellranger_reference"
+	else
+		echo -e "[WARN] CELLRANGER_REFERENCE path DOES NOT EXIST -> $cellranger_reference"
+	fi
+	else
+		echo -e "[WARN] No directory path entered for CELLRANGER_REFERENCE"
 fi
+echo -e "===================================================================================\n\n"
 
-## Gets paths from sample file to use as bind mounts to access sample data
-echo -e "\nChecking if sample directories exist."
-sample_bind_mnts=$(python3 $SCRIPT_DIR/helper_scripts/get_sample_paths.py)
-echo -e "\nSample directory bind mounts for Singularity: $sample_bind_mnts\n"
+echo -e "============= Preliminary analysis files for Singularity bind mounts =============="
+# Check that any files in the prelim_configs.yaml exists, gets their directory for bind mounting
+prelim_file_configs=("TRANSFERDATA_REF_FILE" "REGRESSION_FILE" "USER_GENE_FILE")
+for config in "${prelim_file_configs[@]}"; do
+	# Get the file path by calling cache.py with the config name
+	file_path=$(python3 "$SCRIPT_DIR/helper_scripts/cache.py" "${config}:")
 
-## Gets path to TransferData reference file directory (if TransferData is run)
-if [ "$run_transferdata" = "y" ]; then
-	transferdata_file=`python3 $SCRIPT_DIR/helper_scripts/cache.py TRANSFERDATA_REF_FILE:`
- 	transferdata_dir=$(dirname "$transferdata_file")
-	echo -e "\nTransferData reference file directory bind mount for Singularity: $transferdata_dir\n"
-else
-	transferdata_dir=''
-fi
+	if [[ -z "$file_path" ]]; then
+  		echo -e "[WARN] No file path entered for $config"
+  		continue
+	fi
+
+	# Get the absolute directory path of that file
+	dir=$(realpath "$(dirname "$file_path")")
+
+	# Check dir exsists
+	if [[ -n "$dir" && -d "$dir" ]]; then
+		[[ -n "$prelim_bind_mnts" ]] && prelim_bind_mnts+=","
+		prelim_bind_mnts+="$dir"
+		echo -e "[PASS] File exists for $config: $file_path, directory will be bound -> $dir"
+	else
+    	echo -e "Warning: Directory for $config does not exist: $config -> $dir"
+  	fi
+done
+echo -e "===================================================================================\n\n"
+
+# Remove duplicates
+echo -e "================= Singularity bind mounts for preliminary analysis ================="
+prelim_bind_mnts=$(echo "$prelim_bind_mnts" | tr ',' '\n' | awk '!seen[$0]++' | paste -sd ',' -)
+echo -e "$prelim_bind_mnts"
+echo -e "====================================================================================\n\n\n"
 #-----------------------------------------------------------------------------
 
 # call Snakemake (sans Singularity)
@@ -102,7 +134,7 @@ snakemake --snakefile $SCRIPT_DIR/Snakefile \
 	--cores $threads \
 	--printshellcmds \
 	--use-singularity \
-	--singularity-args "-B $sample_bind_mnts,$cellranger_reference,$transferdata_dir"
+	--singularity-args "-B $prelim_bind_mnts"
 #-----------------------------------------------------------------------------
 
 # show citations again


### PR DESCRIPTION
# Fixes for issue #14: Not all paths to input files are bound in Singularity

## Config **_file path_** checking and mounting
Updated `run_snakemake.sh` to check all configs that are file paths. Prints to console whether the file passes/fails the existence check. If it passes (is not empty and path exists), the dir for the file is added to the string of paths that is mounted with `snakemake --use-singularity --singularity-args "-B $bind_mnts"`.

From `prelim_configs.yaml`:
* `TRANSFERDATA_REF_FILE`
* `REGRESSION_FILE`
* `USER_GENE_FILE`


From `post_annotation_configs.yaml`:
* `CLUSTER_ANNOTATION_FILE`
* `USER_ANALYZED_SEURAT_OBJECT`
* `FINAL_USER_GENE_FILE`

## Config _directory path_ checking and mounting
`CELLRANGER_REFERENCE` will only be checked as a directory. If the config is not empty and exists and is a directory, it will be bound.

## Additional notes
These checks with print out pass/fail info but these check will not interrupt or exit execution. Reasoning: there are lots of checks for config parameter agreements in the Snakefiles. The sample paths being checked in `helper_scripts/get_sample_paths.py` will result in sys.exit if invalid paths found because I don't think that check is performed elsewhere.

## Other changes
- Removed `CELLRANGER_REFERENCE` fake example path from prelim config
- Updating Snakefile to use pond:1.2 container