### PR TITLE
Adding back the loupeR EULA autoaccept

### DIFF
--- a/src/scripts/final_analysis.R
+++ b/src/scripts/final_analysis.R
@@ -136,7 +136,7 @@ if ('cloupe' %in% unlist(final_storage_method)) {
 		download.file.extra = "-k -L")
 
 	# Load library	
-	library(loupeR)
+	library(loupeR, lib.loc=lib_path)
 
 	# Set the EULA auto accept env var to "y"
 	Sys.setenv(AUTO_ACCEPT_EULA = "y")

--- a/src/scripts/final_analysis.R
+++ b/src/scripts/final_analysis.R
@@ -126,6 +126,31 @@ if (is.null(final_storage) == FALSE)
 }
 # --------------------------------------------------------------------
 
+# AUTOACCEPT THE LOUPER EULA
+# --------------------------------------------------------------------
+if ('cloupe' %in% unlist(final_storage_method)) {
+
+	options(
+		repos = c(CRAN = "internalrepo"),
+		download.file.method = "curl",
+		download.file.extra = "-k -L")
+
+	# Load library	
+	library(loupeR)
+
+	# Set the EULA auto accept env var to "y"
+	Sys.setenv(AUTO_ACCEPT_EULA = "y")
+
+	# Assign env var to another env var to comply with:
+	# https://github.com/10XGenomics/loupeR/blob/d7994c5c5bd1fc7a6202e23f84ecf9df43831e6e/R/eula.R
+	AUTO_ACCEPT_ENV_VAR = "AUTO_ACCEPT_EULA"
+
+	# Run the loupeR:::eula() function which will check AUTO_ACCEPT_ENV_VAR with auto_accepted_eula()
+	loupeR:::eula()
+	loupeR::setup()
+}
+# --------------------------------------------------------------------
+
 # IMPORT LIBS
 #--------------------------------------------------------------------
 suppressPackageStartupMessages(library(Seurat, lib.loc=lib_path))


### PR DESCRIPTION
Add back the loupeR autoaccept to restore functionality for loupeR (saving as .cloupe file in `final_analysis.R`).