### PR TITLE
Enhancement/issue 11 cluster execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ benchmark_report/
 count_stamps/
 helper_scripts/make_symbolic_links.sh
 .Renviron
+.Rprofile
 
 # Snakemake folder to ignore
 .snakemake/

--- a/FinalSnakefile
+++ b/FinalSnakefile
@@ -54,7 +54,7 @@ if FINAL_STORAGE is not None:
 	FINAL_STORAGE = FINAL_STORAGE.strip() #remove any spaces
 
 if FINAL_STORAGE is None: 
-	FINAL_STORAGE = 'qs' #making this a list has unintended consequences
+	FINAL_STORAGE = 'qs2' #making this a list has unintended consequences
 
 EULA = config['EULA']
 
@@ -74,7 +74,7 @@ FINAL_THREADS = config['FINAL_THREADS']
 
 # for params with potential for > 1 selection ---------------
 def replace_spaces_commas(config_param_name, config_param):
-	storage_options = ['qs', 'rds', 'sceo', 'cloupe', 'cellchat', 'cellphone']
+	storage_options = ['qs2', 'rds', 'sceo', 'cloupe', 'cellchat', 'cellphone']
 	visualization_options = ['violin', 'ridge', 'dot', 'feature']
 	flag = 1
 
@@ -85,8 +85,8 @@ def replace_spaces_commas(config_param_name, config_param):
 	if config_param.endswith(','):
 		config_param = config_param.rsplit(',', 1)[0] #remove last comma
 
-	if config_param_name == 'FINAL_STORAGE' and 'qs' not in config_param:
-		config_param = 'qs,'+ config_param	
+	if config_param_name == 'FINAL_STORAGE' and 'qs2' not in config_param:
+		config_param = 'qs2,'+ config_param	
 
 	options = []
 	if ',' in config_param:
@@ -98,7 +98,7 @@ def replace_spaces_commas(config_param_name, config_param):
 		if config_param_name == 'FINAL_STORAGE':
 			if o not in storage_options:
 				print('If you would like to save output as RDS, enter \'rds\' for ' + config_param_name + ' in the configs/post_annotation_configs.yaml file, then run this script again')
-				print('P.S. you can have \'sceo\', but that format must be saved as a RDS or QS file.')
+				print('P.S. you can have \'sceo\', but that format must be saved as a RDS or qs2 file.')
 				sys.exit()
 			else:
 				flag = 0
@@ -358,8 +358,8 @@ if PROVIDE_ANALYZED_SEURAT_OBJECT == 'n' or (PROVIDE_ANALYZED_SEURAT_OBJECT == '
 # this will work whether user supplied object or not.
 # if the user has a custom name for Standard or SCT -- need to check in final_analysis.R for nomenclature.
 ident = FINAL_SEURAT_NORMALIZATION_METHOD + '.' + FINAL_SEURAT_INTEGRATION_METHOD + '_snn_res.' + str(FINAL_RESOLUTION)
-analyzed_seurat_object = 'data/endpoints/' + PROJECT + '/analysis/RDS/' +  PROJECT + '_analyzed_seurat_object.qs'
-#final_analyzed_seurat_object = 'data/endpoints/' + PROJECT + '/analysis/RDS/' +  PROJECT + '_final_analyzed_seurat_object.qs'
+analyzed_seurat_object = 'data/endpoints/' + PROJECT + '/analysis/RDS/' +  PROJECT + '_analyzed_seurat_object.qs2'
+#final_analyzed_seurat_object = 'data/endpoints/' + PROJECT + '/analysis/RDS/' +  PROJECT + '_final_analyzed_seurat_object.qs2'
 
 if PROVIDE_ANALYZED_SEURAT_OBJECT == 'y' and os.path.isfile(USER_ANALYZED_SEURAT_OBJECT):
 	analyzed_seurat_object = USER_ANALYZED_SEURAT_OBJECT
@@ -409,15 +409,15 @@ if ',' in FINAL_STORAGE:
 if ',' not in FINAL_STORAGE:
 	options.append(FINAL_STORAGE)
 
-if 'qs' in options:
-	final_analyzed_seurat_object = 'data/endpoints/' + PROJECT + '/analysis/RDS/' +  PROJECT + '_final_analyzed_seurat_object.qs'
+if 'qs2' in options:
+	final_analyzed_seurat_object = 'data/endpoints/' + PROJECT + '/analysis/RDS/' +  PROJECT + '_final_analyzed_seurat_object.qs2'
 
-if 'qs' not in options and 'rds' not in options:
-	options.append('qs')
-	final_analyzed_seurat_object = 'data/endpoints/' + PROJECT + '/analysis/RDS/' +  PROJECT + '_final_analyzed_seurat_object.qs'
-	FINAL_STORAGE = FINAL_STORAGE + ',qs'
+if 'qs2' not in options and 'rds' not in options:
+	options.append('qs2')
+	final_analyzed_seurat_object = 'data/endpoints/' + PROJECT + '/analysis/RDS/' +  PROJECT + '_final_analyzed_seurat_object.qs2'
+	FINAL_STORAGE = FINAL_STORAGE + ',qs2'
 
-if 'qs' not in options and 'rds' in options:
+if 'qs2' not in options and 'rds' in options:
 	final_analyzed_seurat_object = 'data/endpoints/' + PROJECT + '/analysis/RDS/' +  PROJECT + '_final_analyzed_seurat_object.rds'
 
 if 'cloupe' in options:
@@ -468,8 +468,8 @@ for o in options:
 	if o == 'cellchat':
 		if 'rds' in options:
 			storage_item = core_name + '_cellchat.rds'
-		if 'qs' in options:
-			storage_item = core_name + '_cellchat.qs'
+		if 'qs2' in options:
+			storage_item = core_name + '_cellchat.qs2'
 
 	if o == 'cloupe':
 		storage_item = core_name + '.cloupe'
@@ -477,14 +477,14 @@ for o in options:
 	if o == 'sceo':
 		if 'rds' in options:
 			storage_item = core_name + '_sceo.rds'
-		if 'qs' in options:
-			storage_item = core_name + '_sceo.qs'
+		if 'qs2' in options:
+			storage_item = core_name + '_sceo.qs2'
 
 	if o == 'cellphone':
 		cellphoneDB_dir = final_path + 'cellphoneDB/'
 		storage_item = cellphoneDB_dir + PROJECT + '_final_analyzed_cellphoneDB.txt'
 
-	# will need to choose EITHER RDS or QS
+	# will need to choose EITHER RDS or qs2
 	if storage_item not in storage_items:
 		storage_items.append(storage_item)
 	if storage_item not in final_files:

--- a/FinalSnakefile
+++ b/FinalSnakefile
@@ -16,7 +16,7 @@ from helper_scripts.sample_list import get_samples
 import shutil
 import time
 
-container: "docker://francothyroidlab/pond:1.2"
+container: "docker://francothyroidlab/pond:1.3"
 configfile: 'configs/prelim_configs.yaml'
 configfile: 'configs/post_annotation_configs.yaml'
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ TSNE: n
 CONSERVED_GENES: n
 ```
 
-The final analyzed data can be saved as a rds (default: qs file (significantly faster to read/save)). The analyzed data can also be converted to a single cell experimental object. The user may choose one or all storage options.
+The final analyzed data can be saved as a rds (default: qs2 file (significantly faster to read/save)). The analyzed data can also be converted to a single cell experimental object. The user may choose one or all storage options.
 
 ```yaml
 # storage format (rds,sceo)
@@ -385,7 +385,7 @@ ANNOTATE_PROVIDED_FINAL_SEURAT_OBJECT:
 # --------------------------------------------
 ```
 
-What additional ways do you want your final output (qs default)?
+What additional ways do you want your final output (qs2 default)?
 
 ```yaml
 # final storage format (rds,sceo,cloupe,cellchat)
@@ -680,11 +680,11 @@ If there is a failure, there will be additional information in the email (as wel
 ```text
 Error in rule final_analysis:
     jobid: 4
-    input: src/scripts/final_analysis.R, data/endpoints/project_name/analysis/RDS/project_name_analyzed_seurat_object.qs, gene_files/cell_annotation_project_name.txt
-    output: data/endpoints/project_name/analysis/RDS/project_name_final_analyzed_seurat_object.qs, data/endpoints/project_name/analysis/RDS/project_name_final_analyzed_seurat_object.qs
+    input: src/scripts/final_analysis.R, data/endpoints/project_name/analysis/RDS/project_name_analyzed_seurat_object.qs2, gene_files/cell_annotation_project_name.txt
+    output: data/endpoints/project_name/analysis/RDS/project_name_final_analyzed_seurat_object.qs2, data/endpoints/project_name/analysis/RDS/project_name_final_analyzed_seurat_object.qs2
     log: logs/project_name/final_analysis/project_name_final_analysis.log (check log file(s) for error details) **THIS IS WHERE THE LOG FILE IS SAVED**
     shell:
-        Rscript src/scripts/final_analysis.R project_name /usr/local/lib/R/site-library/ data/endpoints/project_name/analysis/RDS/project_name_analyzed_seurat_object.qs 			standard harmony 0.2 			gene_files/cell_annotation_project_name.txt n gene_files/goi_final_project_name.txt 30 			0.1 1.5 0.1 			y 			human qs n  			None dot Sample 			Experiment celltypes 			None None 812454943216 			2> logs/project_name/final_analysis/project_name_final_analysis.log
+        Rscript src/scripts/final_analysis.R project_name /usr/local/lib/R/site-library/ data/endpoints/project_name/analysis/RDS/project_name_analyzed_seurat_object.qs2 			standard harmony 0.2 			gene_files/cell_annotation_project_name.txt n gene_files/goi_final_project_name.txt 30 			0.1 1.5 0.1 			y 			human qs2 n  			None dot Sample 			Experiment celltypes 			None None 812454943216 			2> logs/project_name/final_analysis/project_name_final_analysis.log
         (one of the commands exited with non-zero exit code; note that snakemake uses bash strict mode!)
 
 Shutting down, this might take some time.

--- a/Snakefile
+++ b/Snakefile
@@ -71,10 +71,10 @@ VISUALIZATION = config['VISUALIZATION']
 
 #-------------------------------------------------------------------------------------
 
-# Set storage type to qs if none provided
+# Set storage type to qs2 if none provided
 #-------------------------------------------------------------------------------------
 if STORAGE is None:
-	STORAGE = 'qs'
+	STORAGE = 'qs2'
 #-------------------------------------------------------------------------------------
 
 # Get samples
@@ -95,7 +95,7 @@ if os.path.exists(sample_file) == True:
 def replace_spaces_commas(config_param_name, config_param):
 	normalization_options = ['standard', 'sct']
 	integration_options = ['cca', 'harmony', 'rpca']
-	storage_options = ['qs', 'rds']
+	storage_options = ['qs2', 'rds']
 	visualization_options = ['feature', 'violin', 'ridge', 'dot']
 	flag = 1
 	
@@ -398,7 +398,7 @@ elif RUN_AZIMUTH == 'n':
 if RUN_TRANSFERDATA == 'y':
 	if TRANSFERDATA_REF_FILE is None:
 		print('You have select \'y\' for RUN_TRANSFERDATA; TRANSFERDATA_REF_FILE must be selected.')
-		print('Please provide a path (absolute or relative) to the Seurat object file (.rds or .qs) to be used as the TRANSFERDATA_REF_FILE in the configs/prelim_configs.yaml file, then run this script again.')
+		print('Please provide a path (absolute or relative) to the Seurat object file (.rds or .qs2) to be used as the TRANSFERDATA_REF_FILE in the configs/prelim_configs.yaml file, then run this script again.')
 		sys.exit()
 
 	if os.path.exists(TRANSFERDATA_REF_FILE) == False:
@@ -593,10 +593,10 @@ if REGRESSION_FILE != 'does_not_exist':
 
 # ----------- INITIAL SEURAT AND QC REPORT --------------------------------------------
 #  will save merged seurat object here
-storage_file = string_path + 'analysis/RDS/' + PROJECT + '_initial_seurat_object.qs'
+storage_file = string_path + 'analysis/RDS/' + PROJECT + '_initial_seurat_object.qs2'
 
 if len(SAMPLE_LIST) == 1:
-	storage_file = string_path + 'analysis/RDS/' + PROJECT + '_initial_seurat_object.qs'
+	storage_file = string_path + 'analysis/RDS/' + PROJECT + '_initial_seurat_object.qs2'
 
 # the source for the merging of samples will be the STARTING_DATA, unless soupX is run
 SEURAT_CREATION_SOURCE = STARTING_DATA
@@ -630,7 +630,7 @@ if SEURAT_CREATION_SOURCE == 'cellranger':
 
 # main analyzed seurat object
 #-------------------------------------------------------------------------------------
-analyzed_seurat_object = 'data/endpoints/' + PROJECT + '/analysis/RDS/' +  PROJECT + '_analyzed_seurat_object.qs'
+analyzed_seurat_object = 'data/endpoints/' + PROJECT + '/analysis/RDS/' +  PROJECT + '_analyzed_seurat_object.qs2'
 #-------------------------------------------------------------------------------------
 
 # dge, proportions, dimplots

--- a/Snakefile
+++ b/Snakefile
@@ -14,7 +14,7 @@ from helper_scripts.sample_list import get_samples
 from pathlib import Path 
 import shutil
 
-container: "docker://francothyroidlab/pond:1.2"
+container: "docker://francothyroidlab/pond:1.3"
 configfile: 'configs/prelim_configs.yaml'
 
 # set config parameters

--- a/configs/example_post_annotation_configs.yaml
+++ b/configs/example_post_annotation_configs.yaml
@@ -1,6 +1,9 @@
 # run finale (y/n)
 RUN_FINAL_ANALYSIS: n
 
+# local execution or cluster execution via slurm?
+EXECUTOR: slurm
+
 # minimimum % of cells in one of compared groups for dge
 MIN_PCT: 0.1
 

--- a/configs/example_prelim_configs.yaml
+++ b/configs/example_prelim_configs.yaml
@@ -1,6 +1,9 @@
 # contact (email will be sent when jobs complete) 
 contact: USER@chop.edu
 
+# local execution or cluster execution via slurm?
+EXECUTOR: slurm
+
 # project name (IN LOWER CASE) base_name: (name of output directory under data/endpoints/)
 PROJECT: project_name
 

--- a/configs/example_prelim_configs.yaml
+++ b/configs/example_prelim_configs.yaml
@@ -119,9 +119,8 @@ TSNE: n
 # run conserved genes (y/n) -- only run with multiple experiments
 CONSERVED_GENES: n
 
-# file is automatically saved as qs file.
-# adding rds will create two files (rds + qs)
-# storage format (rds)
+# file is automatically saved as qs2 file.
+# adding rds will create two files (rds + qs2)
 STORAGE: 
 
 # number of threads

--- a/helper_scripts/cache_final.py
+++ b/helper_scripts/cache_final.py
@@ -8,6 +8,7 @@ def get_config(search_config):
 
 	# configs to exclude from lowercasing
 	exclusion_list = (
+		'EXECUTOR',
 		'CLUSTER_ANNOTATION_FILE',
 		'USER_ANALYZED_SEURAT_OBJECT',
 		'FINAL_USER_GENE_FILE'

--- a/profiles/local/config.yaml
+++ b/profiles/local/config.yaml
@@ -1,0 +1,3 @@
+cores: 40
+latency-wait: 60
+printshellcmds: true

--- a/profiles/local/config.yaml
+++ b/profiles/local/config.yaml
@@ -1,3 +1,4 @@
-cores: 40
+cores: 60
+jobs: 10
 latency-wait: 60
 printshellcmds: true

--- a/profiles/slurm/config.yaml
+++ b/profiles/slurm/config.yaml
@@ -11,13 +11,16 @@ default-resources:
   slurm_account: "hpcusers"
   slurm_partition: "defq"
   mem_mb: 8000
-  runtime: 24:00:00
-  time: 24:00:00
+  runtime: 4:00:00
+  time: 4:00:00
   ntasks: 1
   cpus_per_task: 4
 
 set-threads:
   cellranger_counts: 16
+  doubletFinder: 8
+  analyze_sc_object: 16
+  cluster_plots_DGE: 16
 
 set-resources:
   cellranger_counts:
@@ -26,4 +29,23 @@ set-resources:
     time: 24:00:00
     cpus_per_task: 16
     cellranger_jobs: 1
-    
+  soupX:
+    mem_mb: 64000
+    runtime: 4:00:00
+    time: 4:00:00
+    cpus_per_task: 8
+  doubletFinder:
+    mem_mb: 64000
+    runtime: 4:00:00
+    time: 4:00:00
+    cpus_per_task: 8
+  analyze_sc_object:
+    mem_mb: 128000
+    runtime: 8:00:00
+    time: 8:00:00
+    cpus_per_task: 16
+  cluster_plots_DGE:
+    mem_mb: 128000
+    runtime: 6:00:00
+    time: 6:00:00
+    cpus_per_task: 16

--- a/profiles/slurm/config.yaml
+++ b/profiles/slurm/config.yaml
@@ -49,3 +49,13 @@ set-resources:
     runtime: 6:00:00
     time: 6:00:00
     cpus_per_task: 16
+  final_analysis:
+    mem_mb: 128000
+    runtime: 8:00:00
+    time: 8:00:00
+    cpus_per_task: 16
+  trajectory_analysis:
+    mem_mb: 128000
+    runtime: 8:00:00
+    time: 8:00:00
+    cpus_per_task: 16

--- a/profiles/slurm/config.yaml
+++ b/profiles/slurm/config.yaml
@@ -1,0 +1,29 @@
+executor: slurm
+jobs: 100
+latency-wait: 60
+rerun-incomplete: true
+printshellcmds: true
+
+resources:
+  cellranger_jobs: 10
+
+default-resources:
+  slurm_account: "hpcusers"
+  slurm_partition: "defq"
+  mem_mb: 8000
+  runtime: 24:00:00
+  time: 24:00:00
+  ntasks: 1
+  cpus_per_task: 4
+
+set-threads:
+  cellranger_counts: 16
+
+set-resources:
+  cellranger_counts:
+    mem_mb: 64000
+    runtime: 24:00:00
+    time: 24:00:00
+    cpus_per_task: 16
+    cellranger_jobs: 1
+    

--- a/run_snakemake.sh
+++ b/run_snakemake.sh
@@ -231,7 +231,6 @@ profile_dir=$(get_profile_dir "$executor")
 #-----------------------------------------------------------------------------
 snakemake --snakefile $SCRIPT_DIR/Snakefile \
 	--profile $profile_dir \
-	--cores $threads \
 	$dryrun_flag \
 	--use-singularity \
 	--singularity-args "-B $prelim_bind_mnts"
@@ -297,7 +296,6 @@ if [ -e "$final_config_file" ] && [[ $run_final == "y" ]]; then
 	# snakemake --snakefile FinalSnakefile --printshellcmds --dryrun
 	snakemake --snakefile FinalSnakefile \
 		--profile $profile_dir_final \
-		--cores $threads \
 		$dryrun_flag \
 		--use-singularity \
 		--singularity-args "-B $prelim_bind_mnts"

--- a/run_snakemake.sh
+++ b/run_snakemake.sh
@@ -7,6 +7,55 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 sh $SCRIPT_DIR/helper_scripts/citations.sh
 #-----------------------------------------------------------------------------
 
+# Parse command-line options
+#-----------------------------------------------------------------------------
+while getopts ":r:" opt; do
+    case "$opt" in
+        r)
+        case "$OPTARG" in
+            run|dry-run)
+            runtype="$OPTARG"
+            ;;
+            *)
+            log "ERROR" "Invalid runtype: $OPTARG (allowed: run, dry-run)"
+            exit 1
+            ;;
+        esac
+        ;;
+        \?)
+            log "ERROR" "Invalid option: -$OPTARG"
+            echo "Usage: $0 [-r <dry-run|run>]"
+            exit 1
+            ;;
+        :)
+            log "ERROR" "Option -$OPTARG requires an argument"
+            exit 1
+            ;;
+    esac
+done
+
+# Default runtype if not provided
+runtype="${runtype:-run}"
+
+# Get flag for dry-run to pass to snakemake
+dryrun_flag=""
+case "$runtype" in
+    run)
+        dryrun_flag=""
+        ;;
+    dry-run)
+        dryrun_flag="--dry-run"
+        ;;
+    *)
+        log "ERROR" "Unknown runtype: $runtype (allowed: run, dry-run)"
+        exit 1
+        ;;
+esac
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+#-----------------------------------------------------------------------------
+
 # confirm sample list file exists
 #-----------------------------------------------------------------------------
 sample_list_file="samples.sample_list"
@@ -135,7 +184,7 @@ echo -e "=======================================================================
 #-----------------------------------------------------------------------------
 snakemake --snakefile $SCRIPT_DIR/Snakefile \
 	--cores $threads \
-	--printshellcmds \
+	$dryrun_flag \
 	--use-singularity \
 	--singularity-args "-B $prelim_bind_mnts"
 #-----------------------------------------------------------------------------
@@ -194,8 +243,8 @@ if [ -e "$final_config_file" ] && [[ $run_final == "y" ]]; then
 	# snakemake --snakefile FinalSnakefile --printshellcmds --dryrun
 	snakemake --snakefile FinalSnakefile \
 		--cores $threads \
-		--printshellcmds \
+		$dryrun_flag \
 		--use-singularity \
-		--singularity-args "-B $postanno_bind_mnts"
+		--singularity-args "-B $prelim_bind_mnts"
 fi
 #-----------------------------------------------------------------------------

--- a/run_snakemake.sh
+++ b/run_snakemake.sh
@@ -7,6 +7,17 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 sh $SCRIPT_DIR/helper_scripts/citations.sh
 #-----------------------------------------------------------------------------
 
+# ───────────────────────────────────────────────
+# Logging helper
+# ───────────────────────────────────────────────
+log() {
+  local level=$1
+  local message=$2
+  local timestamp
+  timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+  echo "[${timestamp}] [${level}] ${message}" 
+}
+
 # Parse command-line options
 #-----------------------------------------------------------------------------
 while getopts ":r:" opt; do

--- a/run_snakemake.sh
+++ b/run_snakemake.sh
@@ -53,8 +53,26 @@ case "$runtype" in
 esac
 #-----------------------------------------------------------------------------
 
+# Functions
 #-----------------------------------------------------------------------------
+# Function to get profile dir based on the executor specified
+get_profile_dir() {
+    local executor="$1"
+    case "$executor" in
+        local)
+            echo "profiles/local"
+            ;;
+        slurm)
+            echo "profiles/slurm"
+            ;;
+        *)
+            log "ERROR" "Unknown executor: $executor (allowed: local, slurm)"
+            exit 1
+            ;;
+    esac
+}
 #-----------------------------------------------------------------------------
+
 
 # confirm sample list file exists
 #-----------------------------------------------------------------------------
@@ -89,6 +107,9 @@ fi
 # get project name, create dirs, create symbolic links
 #-----------------------------------------------------------------------------
 echo "Setting up project directory"
+
+# Get executor (local or cluster)
+executor=`python3 $SCRIPT_DIR/helper_scripts/cache.py EXECUTOR:`
 
 path="data/endpoints/"
 project=`python3 $SCRIPT_DIR/helper_scripts/cache.py PROJECT:` #retrieves project name from config file
@@ -180,9 +201,25 @@ echo -e "=======================================================================
 # snakemake --cores $threads --snakefile $SCRIPT_DIR/Snakefile
 #-----------------------------------------------------------------------------
 
+# Get the profile to use for prelim analysis
+#-----------------------------------------------------------------------------
+profile_dir=$(get_profile_dir "$executor")
+#-----------------------------------------------------------------------------
+
+
 # call Snakemake with Singularity
+# #-----------------------------------------------------------------------------
+# snakemake --snakefile $SCRIPT_DIR/Snakefile \
+# 	--cores $threads \
+# 	--printshellcmds \
+# 	--use-singularity \
+# 	--singularity-args "-B $prelim_bind_mnts"
+# #-----------------------------------------------------------------------------
+
+# call Snakemake on with profile
 #-----------------------------------------------------------------------------
 snakemake --snakefile $SCRIPT_DIR/Snakefile \
+	--profile $profile_dir \
 	--cores $threads \
 	$dryrun_flag \
 	--use-singularity \
@@ -198,9 +235,15 @@ sh $SCRIPT_DIR/helper_scripts/citations.sh
 #-----------------------------------------------------------------------------
 final_config_file="configs/post_annotation_configs.yaml"
 run_final=`python3 $SCRIPT_DIR/helper_scripts/cache_final.py RUN_FINAL_ANALYSIS:` #retrieves starting data from config file
+executor_final=`python3 $SCRIPT_DIR/helper_scripts/cache_final.py EXECUTOR:`
 
 if [ -e "$final_config_file" ] && [[ $run_final == "y" ]]; then
 	echo "You have the final config file, let the magic begin."
+
+	# Get the profile to use for final analysis
+	#-----------------------------------------------------------------------------
+	profile_dir_final=$(get_profile_dir "$executor_final")
+	#-----------------------------------------------------------------------------
 
 	# Get paths for Singularity bind mounts (post-annotation analysis)
 	#-----------------------------------------------------------------------------
@@ -242,6 +285,7 @@ if [ -e "$final_config_file" ] && [[ $run_final == "y" ]]; then
 
 	# snakemake --snakefile FinalSnakefile --printshellcmds --dryrun
 	snakemake --snakefile FinalSnakefile \
+		--profile $profile_dir_final \
 		--cores $threads \
 		$dryrun_flag \
 		--use-singularity \

--- a/src/rules/analyze_seurat_object.rules
+++ b/src/rules/analyze_seurat_object.rules
@@ -1,7 +1,9 @@
+'''
 # Author: K. Beigel
 # Date: 7.23.2024
 # Purpose: Analyze Seurat object.
 # --------------------------------------------------------------
+'''
 
 #--------------------MESSAGES-----------------------------------
 onsuccess:
@@ -88,4 +90,5 @@ rule analyze_sc_object:
         --processes {params.processes} \
         --memory_file {input.m_file} \
         --regression_file {params.regression_file} \
-        {params.lib_path} 2> {log.log_output}"
+        {params.lib_path} \
+        > {log.log_output} 2>&1"

--- a/src/rules/cellranger.rules
+++ b/src/rules/cellranger.rules
@@ -31,8 +31,14 @@ rule cellranger_counts:
 	benchmark: benchmark_log + PROJECT + '_{s}_cellranger_counts.benchmark'
 	container: 'docker://francothyroidlab/cellranger:9.0.1'
 	shell:
-		"cellranger count --id={wildcards.s} \
-		--fastqs={input.fastqs} --output-dir={params.counts} \
-		--sample={wildcards.s} \
-		--transcriptome={params.reference} {params.bam} \
-		--localcores={threads} --localmem=128 2> {log.log_output} && touch {output.stamp}"
+		"cellranger count \
+			--id={wildcards.s} \
+			--fastqs={input.fastqs} \
+			--output-dir={params.counts} \
+			--sample={wildcards.s} \
+			--transcriptome={params.reference} \
+			--localcores={threads} \
+			--localmem=128 \
+			--disable-ui \
+			{params.bam} \
+			2> {log.log_output} && touch {output.stamp}"

--- a/src/rules/cellranger.rules
+++ b/src/rules/cellranger.rules
@@ -41,4 +41,4 @@ rule cellranger_counts:
 			--localmem=128 \
 			--disable-ui \
 			{params.bam} \
-			2> {log.log_output} && touch {output.stamp}"
+			> {log.log_output} 2>&1 && touch {output.stamp}"

--- a/src/rules/create_images_DGE.rules
+++ b/src/rules/create_images_DGE.rules
@@ -52,6 +52,7 @@ rule cluster_plots_DGE:
 			--report_table_path {params.report_path} \
 			--user_gene_file {params.user_gene_file} \
 			--visualization {params.visualization} \
-			{params.rpath} 2> {log.log_output} && touch {output}"
+			{params.rpath} \
+			> {log.log_output} 2>&1 && touch {output}"
 		
 

--- a/src/rules/create_initial_seurat.rules
+++ b/src/rules/create_initial_seurat.rules
@@ -38,11 +38,18 @@ rule create_initial_seurat:
     benchmark: benchmark_log + PROJECT.lower() + '_create_initial_seurat.benchmark'
     shell:
         "Rscript {input.script} \
-        --sample_file {params.sample_file} --project {params.project} --organism {params.organism} \
-        --seurat_creation_source {params.seurat_creation_source} --run_doubletfinder {params.run_doubletfinder} \
-        --mito_cutoff {params.mito} --ribo_cutoff {params.ribo} --min_feature_threshold {params.min_feature_threshold} \
-        --max_feature_threshold {params.max_feature_threshold} --seurat_file_name {params.seurat_file_name} \
-        {params.r_lib_path} 2> {log.log_output}"
+        --sample_file {params.sample_file} \
+        --project {params.project} \
+        --organism {params.organism} \
+        --seurat_creation_source {params.seurat_creation_source} \
+        --run_doubletfinder {params.run_doubletfinder} \
+        --mito_cutoff {params.mito} \
+        --ribo_cutoff {params.ribo} \
+        --min_feature_threshold {params.min_feature_threshold} \
+        --max_feature_threshold {params.max_feature_threshold} \
+        --seurat_file_name {params.seurat_file_name} \
+        {params.r_lib_path} \
+        > {log.log_output} 2>&1"
 
 rule make_qc_report:
     input:

--- a/src/rules/doubletFinder.rules
+++ b/src/rules/doubletFinder.rules
@@ -46,5 +46,5 @@ rule doubletFinder:
     --sequencing_type {params.sequencing_type} \
     --processes {threads} \
     {params.lib_path} \
-    2> {log.log_output}"
+    > {log.log_output} 2>&1"
 

--- a/src/rules/final_analysis.rules
+++ b/src/rules/final_analysis.rules
@@ -60,7 +60,7 @@ rule final_analysis:
 			{params.annotate} {params.visualization} {params.meta_sample} \
 			{params.meta_experiment} {params.meta_annotation} \
 			{params.umap_reduction} {params.tnse_reduction} {params.memory} \
-			2> {log.log_output}" 
+			> {log.log_output} 2>&1" 
 
 rule trajectory_analysis:
 	input:
@@ -90,7 +90,7 @@ rule trajectory_analysis:
 			{params.final_storage} \
 			{params.lib_path} \
 			{params.provide} {params.annotate} \
-			2> {log.log_output} && touch {output}"
+			> {log.log_output} 2>&1 && touch {output}"
 			
 rule final_report:
 	input:
@@ -121,7 +121,7 @@ rule benchmarks:
 		log_output = benchmarking_table_log + PROJECT + '_benchmarking_table.log'
 	benchmark: benchmark_log + PROJECT + '_benchmark_table.benchmark'
 	shell:
-		"Rscript {input.script} {params.lib_path} {params.project} 2> {log.log_output}"
+		"Rscript {input.script} {params.lib_path} {params.project} > {log.log_output} 2>&1"
 
 rule bench_report:
 	input:

--- a/src/rules/get_memory.rules
+++ b/src/rules/get_memory.rules
@@ -26,4 +26,4 @@ rule memory:
 		"cells=$( zcat {params.barcodes_files} | wc -l) && \
 			genes=$( zcat {params.features_files} | wc -l) && \
 			echo $(( $cells * $genes * 8 )) > {output.m_file} \
-			> {log.log_output} 2>&1"
+			2> {log.log_output}"

--- a/src/rules/get_memory.rules
+++ b/src/rules/get_memory.rules
@@ -26,4 +26,4 @@ rule memory:
 		"cells=$( zcat {params.barcodes_files} | wc -l) && \
 			genes=$( zcat {params.features_files} | wc -l) && \
 			echo $(( $cells * $genes * 8 )) > {output.m_file} \
-			2> {log.log_output}"
+			> {log.log_output} 2>&1"

--- a/src/rules/multiQC.rules
+++ b/src/rules/multiQC.rules
@@ -27,6 +27,10 @@ rule multiqc_cellranger_report:
 		log_output = multiqc_log + 'multiqc_cellranger_report.log'
 	benchmark: benchmark_log + PROJECT.lower() + '_multiqc_cellranger.benchmark'
 	shell:
-		"multiqc {params.search_dir} -m {params.module} \
-			 --filename {params.report_name} -o {params.outdir} \
-			 --verbose --force 2> {log.log_output}" 
+		"multiqc {params.search_dir} \
+			-m {params.module} \
+			--filename {params.report_name} \
+			-o {params.outdir} \
+			--verbose \
+			--force \
+			> {log.log_output} 2>&1" 

--- a/src/rules/soupX.rules
+++ b/src/rules/soupX.rules
@@ -40,4 +40,5 @@ rule soupX:
 		--soupX_output_path  {params.soupx_output} \
 		--sequencing_type {params.sequencing_type} \
 		--starter_data {params.starting_data} \
-		{params.r_lib_path} 2> {log.log_output}"
+		{params.r_lib_path} \
+		> {log.log_output} 2>&1"

--- a/src/scripts/analyze_seurat_object.R
+++ b/src/scripts/analyze_seurat_object.R
@@ -164,12 +164,15 @@ memory <- as.numeric(memory_f$V1)
 # PARALLEL w/ FUTURE + SET SEED
 # --------------------------------------------------------------------
 print(paste0('Assigning ', memory, ' bytes of memory...'))
+options(future.seed = TRUE)
 options(future.globals.maxSize = memory)
-#options(future.globals.onReference = 'error')
-plan(multisession(workers = as.integer(processes)))
-#plan(multisession(workers = 1)) # if higher number of samples and sct.rpca, runs out of memory (future issue)
+plan(multicore, workers = as.integer(processes))
 
 set.seed(42)
+
+#options(future.globals.onReference = 'error')
+# plan(multisession(workers = as.integer(processes)))
+#plan(multisession(workers = 1)) # if higher number of samples and sct.rpca, runs out of memory (future issue)
 # --------------------------------------------------------------------
 
 # FUNCTION: PARSE COMMA-SEP STRINGS TO LISTS

--- a/src/scripts/analyze_seurat_object.R
+++ b/src/scripts/analyze_seurat_object.R
@@ -25,7 +25,7 @@ tryCatch(
 
 option_list <- list(
   make_option(c("--initial_seurat_object"), type = "character",
-              help = "Path to the initial Seurat object (qs or rds), likely from create_initial_seurat.R."),
+              help = "Path to the initial Seurat object (qs2 or rds), likely from create_initial_seurat.R."),
   make_option(c("--project"), type = "character",
               help = "Project name for output files."),
   make_option(c("--organism"), type = "character",
@@ -63,7 +63,7 @@ option_list <- list(
   make_option(c("--run_transferdata"), type = "character",
               help = "Whether to run TransferData annotation (y/n)."),
   make_option(c("--transferdata_ref_file"), type = "character",
-              help = "Path to the TransferData reference file (qs or rds)."),
+              help = "Path to the TransferData reference file (qs2 or rds)."),
   make_option(c("--transferdata_reduction"), type = "character",
               help = "Reduction to use for TransferData (e.g., pca, umap)."),
   make_option(c("--transferdata_annocol"), type = "character",
@@ -73,7 +73,7 @@ option_list <- list(
   make_option(c("--include_tsne"), type = "character",
               help = "Whether to include tSNE reduction (y/n)."),
   make_option(c("--analyzed_seurat_object"), type = "character",
-              help = "Path to save the analyzed Seurat object (qs)."),
+              help = "Path to save the analyzed Seurat object (qs2)."),
   make_option(c("--report_path_figures"), type = "character",
               help = "Path to save figures for the report."),
   make_option(c("--processes"), type = "integer", default = 4,
@@ -122,7 +122,7 @@ regression_file <- if (is.null(opt$options$regression_file) || !file.exists(opt$
 # --------------------------------------------------------------------
 suppressMessages(library(future, lib.loc = lib_path))
 suppressMessages(library(tools, lib.loc = lib_path))
-suppressMessages(library(qs, lib.loc = lib_path))
+suppressMessages(library(qs2, lib.loc = lib_path))
 suppressMessages(library(Seurat, lib.loc = lib_path))
 suppressMessages(library(clustree, lib.loc = lib_path))
 if (run_azimuth == 'y')
@@ -239,7 +239,7 @@ if (length(resolution_config_list) > 1)
 import_data = function(filename, filetype)
 {
   print('Loading Seurat object.')
-  seurat.object = qread(file = filename)
+  seurat.object = qs2::qs_read(file = filename)
 
   return(seurat.object)
 }
@@ -539,14 +539,14 @@ load_transferdata_ref = function(transferdata.ref.file, transferdata.reduction)
   # Call load fxn based on extension
   transferdata.ref = switch(
     file_ext(transferdata.ref.file),
-    qs = qread(transferdata.ref.file),
+    qs2 = qs2::qs_read(transferdata.ref.file),
     rds = readRDS(transferdata.ref.file),
-    stop('The reference file provided for TransferData is not a qs or rds file.')
+    stop('The reference file provided for TransferData is not a qs2 or rds file.')
   )
 
   # Check that object is Seurat class
   if (class(transferdata.ref)[1] != 'Seurat') {
-    stop('Please provide a Seurat object saved as a qs or rds file.')
+    stop('Please provide a Seurat object saved as a qs2 or rds file.')
   }
 
   if (!transferdata.reduction %in% names(transferdata.ref@reductions)) {
@@ -742,8 +742,8 @@ run_clustering = function(seurat.object, integration.method.list = NULL, normali
 
 # SEURAT ANALYSIS
 # --------------------------------------------------------------------
-# LOAD THE MERGED OBJECT (rds or qs)
-S = import_data(initial_seurat_object, 'qs')
+# LOAD THE MERGED OBJECT (rds or qs2)
+S = import_data(initial_seurat_object, 'qs2')
 
 # GET NUMBER OF SAMPLES
 n_samples = length(unique(S@meta.data[['Sample']]))
@@ -785,5 +785,5 @@ if (run_transferdata == 'y') {
 S = run_clustering(S, integration_method_list, normalization_method_list, resolution_config_list, include_tsne)
 
 # SAVE OBJECT
-qsave(S, analyzed_seurat_object)
+qs2::qs_save(S, analyzed_seurat_object)
 # --------------------------------------------------------------------

--- a/src/scripts/analyze_seurat_object.R
+++ b/src/scripts/analyze_seurat_object.R
@@ -207,8 +207,12 @@ normalization_assay_dict = list('standard' = 'RNA', 'sct' = 'SCT')
 normalization_method_list = normalization_assay_dict[normalization_config_list]
 
 # INTEGRATION METHODS: list of what each config term for integration will be
-integration_dict = list('cca' = 'CCAIntegration', 'rpca' = 'RPCAIntegration', 'harmony' = 'HarmonyIntegration',
-                        'pca' = 'PCA') # need this here so this passes properly to fns that use the integration_method_list
+integration_dict = list(
+  'cca' = 'CCAIntegration',
+  'rpca' = 'RPCAIntegration',
+  'harmony' = 'HarmonyIntegration',
+  'pca' = 'PCA'
+)
 
 # Subset to a list of the input methods from config with Seurat int names
 integration_method_list = integration_dict[integration_config_list]
@@ -495,19 +499,29 @@ seurat_integration = function(seurat.object, integration.method.list, normalizat
 
         print('Reference-based integration')
         # Run integration (reference-based)
-        seurat.object = IntegrateLayers(object = seurat.object, method = integration.method.name,
-                                        assay = norm.assay, normalization.method = norm.method,
-                                        orig.reduction = pca.name, new.reduction = int.reduction.name,
-                                        reference = ref.sample.index)
+        seurat.object = IntegrateLayers(
+          object = seurat.object,
+          method = integration.method.name,
+          assay = norm.assay,
+          normalization.method = norm.method,
+          orig.reduction = pca.name,
+          new.reduction = int.reduction.name,
+          reference = ref.sample.index
+        )
       }
 
       if (ref_based_integration == 'n')
       {
         print('Integration')
         # Run integration (normal)
-        seurat.object = IntegrateLayers(object = seurat.object, method = integration.method.name,
-                                        assay = norm.assay, normalization.method = norm.method,
-                                        orig.reduction = pca.name, new.reduction = int.reduction.name)
+        seurat.object = IntegrateLayers(
+          object = seurat.object,
+          method = integration.method.name,
+          assay = norm.assay,
+          normalization.method = norm.method,
+          orig.reduction = pca.name,
+          new.reduction = int.reduction.name
+        )
       }
     }
   }
@@ -636,24 +650,37 @@ find_neighbors_clusters_reductions = function(seurat.object, sig.pcs, reduction.
 {
   # FIND NEIGHBORS
   set.seed(42)
-  seurat.object = FindNeighbors(seurat.object, reduction = reduction.name, dims = 1:sig.pcs,
-                                graph.name = paste0(reduction.name, c('_nn', '_snn')))
+  seurat.object = FindNeighbors(
+    seurat.object,
+    reduction = reduction.name,
+    dims = 1:sig.pcs,
+    graph.name = paste0(reduction.name, c('_nn', '_snn'))
+  )
 
   umap.name = paste0(reduction.name, '.umap')
   umap.key = paste0(gsub('\\.', '', reduction.name), 'UMAP_') # RunUMAP doesn't like '.'
 
   # RUN UMAP
   print(paste('Running UMAP for', reduction.name))
-  seurat.object = RunUMAP(seurat.object, reduction = reduction.name, dims = 1:sig.pcs,
-                            reduction.key = umap.key, reduction.name = umap.name)
+  seurat.object = RunUMAP(
+    seurat.object,
+    reduction = reduction.name,
+    dims = 1:sig.pcs,
+    reduction.key = umap.key,
+    reduction.name = umap.name
+  )
 
   if (include.tsne == 'y')
   {
     # RUN TSNE
     print(paste('Running tSNE for', reduction.name))
-    seurat.object = RunTSNE(seurat.object, reduction = reduction.name, dims = 1:sig.pcs,
-                            reduction.key = paste0(gsub('\\.', '', reduction.name), 'tSNE_'),
-                            reduction.name = paste0(reduction.name, '.tsne'))
+    seurat.object = RunTSNE(
+      seurat.object,
+      reduction = reduction.name,
+      dims = 1:sig.pcs,
+      reduction.key = paste0(gsub('\\.', '', reduction.name), 'tSNE_'),
+      reduction.name = paste0(reduction.name, '.tsne')
+    )
   }
 
   # Define the graph.name that is needed for FindClusters
@@ -667,14 +694,29 @@ find_neighbors_clusters_reductions = function(seurat.object, sig.pcs, reduction.
 	 algorithm = as.integer(algorithm)
 
     # FIND CLUSTERS BASED ON THE GRAPH AND RES (graph.name_snn_resN.N)
-    seurat.object = FindClusters(seurat.object, resolution = res, graph.name = graph.name, algorithm = algorithm, verbose = FALSE)
+    seurat.object = FindClusters(
+      seurat.object,
+      resolution = res,
+      graph.name = graph.name,
+      algorithm = algorithm,
+      verbose = FALSE
+    )
 
     clust.res = paste0(graph.name, '_res.', res) # if periods need to be removed: gsub('\\.', '_', graph.name)
 
     print(paste('Plotting', clust.res, 'ON', umap.name))
 
     pdf(file = paste0(report_path_figures, '/', project, '_', clust.res, '_clusters_umap.pdf'), width = 10, height = 10)
-    print(DimPlot(seurat.object, reduction = umap.name, group.by = clust.res, label = TRUE, label.size = 6, repel = TRUE) + NoLegend())
+    print(
+      DimPlot(
+        seurat.object,
+        reduction = umap.name,
+        group.by = clust.res,
+        label = TRUE,
+        label.size = 6,
+        repel = TRUE
+      ) + NoLegend()
+    )
     dev.off()
   }
 

--- a/src/scripts/create_images_DGE.R
+++ b/src/scripts/create_images_DGE.R
@@ -428,7 +428,7 @@ proportions_UMAP_DGE <- function(seurat_object, num_samples, visi, genes=genes, 
         # DGEA -------------------------
         if (n == 'sct')
         {
-          print('Preping seurat object (sct assay)...')
+          print('Prepping seurat object (sct assay)...')
           set.seed(42)
           seurat_object <- PrepSCTFindMarkers(object = seurat_object)
         }

--- a/src/scripts/create_images_DGE.R
+++ b/src/scripts/create_images_DGE.R
@@ -34,7 +34,7 @@ option_list <- list(
   make_option(c('--conserved_genes'), type='character', default='n', help='Whether to find conserved genes across experiments. Options are \'y\' or \'n\'. Default is \'n\'.'),
   make_option(c('--analyzed_seurat_object'), type='character', help='Path to the analyzed Seurat object file (RDS or qs2 format).'),
   make_option(c('--processes'), type='integer', default=1, help='Number of processes to use for parallel computation. Default is 1.'),
-  make_option(c('--memory'), type='integer', help='Max amount of memory.'),
+  make_option(c('--memory'), type='numeric', help='Max amount of memory.'),
   make_option(c('--tsne_plot'), type='character', default='n', help='Whether to create tSNE plots. Options are \'y\' or \'n\'. Default is \'n\'.'),
   make_option(c('--report_table_path'), type='character', help='Path to save report tables. Default is \'data/endpoints/{project}reports/\'.'),
   make_option(c('--user_gene_file'), type='character', help='Path to a user-defined gene file for visualization. Default is \'does_not_exist\'.'),
@@ -52,7 +52,7 @@ resolution <- if (is.null(opt$options$resolution)) stop('--resolution is require
 conserved_genes <- if (is.null(opt$options$conserved_genes)) stop('--conserved_genes is required. See --help for all opts') else opt$options$conserved_genes
 analyzed_seurat_object <- if (is.null(opt$options$analyzed_seurat_object) || !file.exists(opt$options$analyzed_seurat_object)) stop('--analyzed_seurat_object is required and must be a valid file path. See --help for all opts')  else opt$options$analyzed_seurat_object
 processes <- opt$options$processes
-memory <- as.integer(opt$options$memory)
+memory <- as.numeric(opt$options$memory)
 tsne_plot <- if (is.null(opt$options$tsne_plot)) stop('--tsne_plot is required. See --help for all opts') else opt$options$tsne_plot
 report_table_path <- if (is.null(opt$options$report_table_path)) stop('--report_table_path is required. See --help for all opts') else opt$options$report_table_path
 user_gene_file <- if (is.null(opt$options$user_gene_file) || !file.exists(opt$options$user_gene_file)) 'does_not_exist' else opt$options$user_gene_file

--- a/src/scripts/create_images_DGE.R
+++ b/src/scripts/create_images_DGE.R
@@ -75,10 +75,13 @@ suppressPackageStartupMessages(library(tidyverse, lib.loc=lib_path))
 # PARALLEL w/ FUTURE + SET SEED
 #--------------------------------------------------------------------
 #print(c(memory, class(memory), type(memory)))
-options(future.globals.maxSize = memory) # 210000 * 1024^2) #may make variable so user can increase if failure based on dataset size???
-plan(multisession(workers = as.integer(processes)))
+options(future.seed = TRUE)
+options(future.globals.maxSize = as.numeric(memory))
+plan(multicore, workers = as.integer(processes))
 
 set.seed(42)
+
+# plan(multisession(workers = as.integer(processes)))
 #--------------------------------------------------------------------
 
 # FUNCTION: determine if argument is single value or list

--- a/src/scripts/create_images_DGE.R
+++ b/src/scripts/create_images_DGE.R
@@ -27,12 +27,12 @@ tryCatch(
 
 option_list <- list(
   make_option(c('--project'), type='character', help='Project name, used to create output directories and file names.'),
-  make_option(c('--storage'), type='character', default='rds', help='Storage format for the analyzed Seurat object, either \'rds\' or \'qs\'.'),
+  make_option(c('--storage'), type='character', default='rds', help='Storage format for the analyzed Seurat object, either \'rds\' or \'qs2\'.'),
   make_option(c('--normalization_method'), type='character', help='Normalization method(s) to use, comma-separated. Options are \'sct\' and \'standard\'.'),
   make_option(c('--integration_method'), type='character', help='Integration method(s) to use, comma-separated. Options are \'cca\', \'harmony\', \'rpca\', and \'sct\'.'),
   make_option(c('--resolution'), type='character', help='Resolution(s) to use for clustering, comma-separated.'),
   make_option(c('--conserved_genes'), type='character', default='n', help='Whether to find conserved genes across experiments. Options are \'y\' or \'n\'. Default is \'n\'.'),
-  make_option(c('--analyzed_seurat_object'), type='character', help='Path to the analyzed Seurat object file (RDS or QS format).'),
+  make_option(c('--analyzed_seurat_object'), type='character', help='Path to the analyzed Seurat object file (RDS or qs2 format).'),
   make_option(c('--processes'), type='integer', default=1, help='Number of processes to use for parallel computation. Default is 1.'),
   make_option(c('--memory'), type='integer', help='Max amount of memory.'),
   make_option(c('--tsne_plot'), type='character', default='n', help='Whether to create tSNE plots. Options are \'y\' or \'n\'. Default is \'n\'.'),
@@ -66,7 +66,7 @@ suppressPackageStartupMessages(library(Seurat, lib.loc=lib_path))
 suppressPackageStartupMessages(library(ggplot2, lib.loc=lib_path))
 suppressPackageStartupMessages(library(reshape2, lib.loc=lib_path))
 suppressPackageStartupMessages(library(data.table, lib.loc=lib_path))
-suppressPackageStartupMessages(library(qs, lib.loc=lib_path))
+suppressPackageStartupMessages(library(qs2, lib.loc=lib_path))
 suppressPackageStartupMessages(library(future, lib.loc=lib_path))
 suppressPackageStartupMessages(library(progressr, lib.loc=lib_path))
 suppressPackageStartupMessages(library(presto, lib.loc=lib_path))
@@ -517,7 +517,7 @@ proportions_UMAP_DGE <- function(seurat_object, num_samples, visi, genes=genes, 
 # --------------------------------------------------------------------------------------------
 # IMPORT DATA
 print('importing data...')
-S = qread(analyzed_seurat_object)
+S = qs2::qs_read(analyzed_seurat_object)
 # ------------------------------------------------
 
 # GET NUMBER OF SAMPLES

--- a/src/scripts/create_initial_seurat.R
+++ b/src/scripts/create_initial_seurat.R
@@ -46,7 +46,7 @@ option_list <- list(
 library(tidyverse, lib.loc = lib_path)
 library(rcartocolor, lib.loc = lib_path)
 library(Seurat, lib.loc = lib_path)
-library(qs, lib.loc = lib_path)
+library(qs2, lib.loc = lib_path)
 library(patchwork, lib.loc = lib_path)
 library(dplyr, lib.loc = lib_path)
 
@@ -306,7 +306,7 @@ filter_save_seuobj = function(seu.obj)
 
   # save filtered object
   print('Saving Seurat object.')
-  qsave(seu.obj.filt, file = seurat_file_name)
+  qs2::qs_save(seu.obj.filt, file = seurat_file_name)
 }
 #--------------------------------------------------------------------
 

--- a/src/scripts/create_initial_seurat.R
+++ b/src/scripts/create_initial_seurat.R
@@ -298,7 +298,10 @@ filter_save_seuobj = function(seu.obj)
   # filter
   filter_info = paste0('nFeature_RNA > ', min_feature_threshold, ', nFeature_RNA < ', max_feature_threshold, ', percent.mito < ', mito_cutoff, ', percent.ribo < ', ribo_cutoff)
   print(paste0('Filtering Seurat object: ', filter_info))
-  seu.obj.filt <- subset(seu.obj, subset = nFeature_RNA > min_feature_threshold & nFeature_RNA < max_feature_threshold & percent.mito < mito_cutoff & percent.ribo < ribo_cutoff)
+  seu.obj.filt <- subset(
+    seu.obj,
+    subset = nFeature_RNA > min_feature_threshold & nFeature_RNA < max_feature_threshold & percent.mito < mito_cutoff & percent.ribo < ribo_cutoff
+  )
 
   # post-filtered plots
   print('Plotting QC figures for data (filtered).')

--- a/src/scripts/doubletFinder.R
+++ b/src/scripts/doubletFinder.R
@@ -76,10 +76,13 @@ suppressMessages(library(DoubletFinder, lib.loc = lib_path))
 #--------------------------------------------------------------------
 # PARALLEL w/ FUTURE + SET SEED
 # --------------------------------------------------------------------
+options(future.seed = TRUE)
 options(future.globals.maxSize = 20000 * 1024^2)
-plan(multisession(workers = as.integer(processes)))
+plan(multicore, workers = as.integer(processes))
 
 set.seed(42)
+
+# plan(multisession(workers = as.integer(processes)))
 # --------------------------------------------------------------------
 
 # ASSIGN GLOBAL VARIABLES

--- a/src/scripts/doubletFinder.R
+++ b/src/scripts/doubletFinder.R
@@ -297,9 +297,10 @@ write_doublet_ids <- function(seurat.object, sample, project)
   # define it as a Doublet in the final Doublet_Classification
   doublet.class = seurat.object@meta.data[, doublet.col.list] %>%
     mutate(DF_Classification = case_when(
-		if_any(all_of(doublet.col.list), ~ .x == 'Doublet') ~ 'Doublet',  TRUE ~ 'Singlet')  # Check across columns
-      #if_any(c(doublet.col.list), ~ .x == 'Doublet') ~ 'Doublet', .default = 'Singlet')
+		  if_any(all_of(doublet.col.list), ~ .x == 'Doublet') ~ 'Doublet', 
+      TRUE ~ 'Singlet'
     )
+  )
   
   # Add final Doublet classification to the Seurat object
   seurat.object = AddMetaData(seurat.object, metadata = doublet.class$DF_Classification, col.name = 'DF_Classification')

--- a/src/scripts/final_analysis.R
+++ b/src/scripts/final_analysis.R
@@ -117,7 +117,7 @@ integration_method = single_or_list(integration_method)
 final_storage_method = ''
 if (is.null(final_storage) == TRUE)
 {
-	final_storage_method = as.list('qs')
+	final_storage_method = as.list('qs2')
 }
 
 if (is.null(final_storage) == FALSE)
@@ -163,7 +163,7 @@ suppressPackageStartupMessages(library(sctransform, lib.loc=lib_path))
 suppressPackageStartupMessages(library(ggplot2, lib.loc=lib_path))
 suppressPackageStartupMessages(library(reshape2, lib.loc=lib_path))
 suppressPackageStartupMessages(library(data.table, lib.loc=lib_path))
-suppressPackageStartupMessages(library(qs, lib.loc=lib_path))
+suppressPackageStartupMessages(library(qs2, lib.loc=lib_path))
 suppressPackageStartupMessages(library(future, lib.loc=lib_path))
 suppressPackageStartupMessages(library(progressr, lib.loc=lib_path))
 suppressPackageStartupMessages(library(presto, lib.loc=lib_path))
@@ -1190,11 +1190,11 @@ save_seurat_object <- function(seurat_object, rds_dir, project, final_storage_me
 				saveRDS(SCEO, file = f_name)
 			}
 		
-			if ('qs' %in% final_storage_method)
+			if ('qs2' %in% final_storage_method)
 			{
-				print('saving sceo as qs file')
-				f_name = paste0(core_name, '_sceo.qs')
-				qsave(SCEO, file = f_name)
+				print('saving sceo as qs2 file')
+				f_name = paste0(core_name, '_sceo.qs2')
+				qs2::qs_save(SCEO, file = f_name)
 			}
 		}
 	}
@@ -1203,10 +1203,10 @@ save_seurat_object <- function(seurat_object, rds_dir, project, final_storage_me
 	{
 		print(s)
 
-		# saving s.o. in qs format 
-		#print('saving object as qs file...')
-		#f_name_qs = paste0(core_name, '.qs')
-		#qsave(seurat_object, f_name_qs)
+		# saving s.o. in qs2 format 
+		#print('saving object as qs2 file...')
+		#f_name_qs2 = paste0(core_name, '.qs2')
+		#qs2::qs_save(seurat_object, f_name_qs2)
 
 		if (s == 'cellphone')
 		{
@@ -1234,18 +1234,18 @@ save_seurat_object <- function(seurat_object, rds_dir, project, final_storage_me
 				saveRDS(cellChat, file = f_name)
 			}
 
-			if ('qs' %in% final_storage_method)
+			if ('qs2' %in% final_storage_method)
 			#if (grepl( 'rds', final_storage_method, fixed = TRUE) == FALSE)
 			{
-				f_name = paste0(core_name, '_cellchat.qs')
-				qsave(cellChat, f_name)
+				f_name = paste0(core_name, '_cellchat.qs2')
+				qs2::qs_save(cellChat, f_name)
 			}
 		}
 
-		# Always save as .qs !!!
-		print('You have requested a qs file...OK')
-		f_name = paste0(core_name, '.qs')
-		qsave(seurat_object, f_name)
+		# Always save as .qs2 !!!
+		print('You have requested a qs2 file...OK')
+		f_name = paste0(core_name, '.qs2')
+		qs2::qs_save(seurat_object, f_name)
 
 		if (s == 'rds')
 		{
@@ -1292,9 +1292,9 @@ S <- ''
 #--------------------------------------------------------------------
 extension = file_ext(analyzed_seurat_object)
 
-if (extension == 'qs')
+if (extension == 'qs2')
 {
-	S = qread(analyzed_seurat_object)
+	S = qs2::qs_read(analyzed_seurat_object)
 }
 
 if (extension == 'rds')
@@ -1302,10 +1302,10 @@ if (extension == 'rds')
 	S = readRDS(analyzed_seurat_object)
 }
 
-if (extension != 'rds' & extension != 'qs')
+if (extension != 'rds' & extension != 'qs2')
 {
-	print('The provided seurat file is not a qs or rds file.')
-	print('This script will fail. Please save the seurat file as a qs or rds file.')
+	print('The provided seurat file is not a qs2 or rds file.')
+	print('This script will fail. Please save the seurat file as a qs2 or rds file.')
 	stop()
 }
 #--------------------------------------------------------------------

--- a/src/scripts/final_analysis.R
+++ b/src/scripts/final_analysis.R
@@ -179,10 +179,14 @@ suppressPackageStartupMessages(library(tools, lib.loc=lib_path))
 # PARALLEL w/ FUTURE + SET SEED
 #--------------------------------------------------------------------
 print(paste0('Assigning ', memory, ' bytes of memory...'))
-options(future.globals.maxSize = memory)
-#options(future.globals.maxSize = 10001 * 1024^2) 
-plan(multisession(workers = as.integer(processes)))
+options(future.seed = TRUE)
+options(future.globals.maxSize = as.numeric(memory))
+plan(multicore, workers = as.integer(processes))
+
 set.seed(42)
+
+# plan(multisession(workers = as.integer(processes)))
+#options(future.globals.maxSize = 10001 * 1024^2) 
 #--------------------------------------------------------------------
 
 # COLOR SCHEME

--- a/src/scripts/soupX.R
+++ b/src/scripts/soupX.R
@@ -109,7 +109,7 @@ filtered_h5 <- ''
 
 if (sequencing_type == 'standard')
 {
-	cellranger_data = paste(soupX_input_path, 'outs/', sep='')
+	cellranger_data = file.path(soupX_input_path, 'outs')
 	raw_folder <- 'raw_feature_bc_matrix'
 	filtered_folder <- 'filtered_feature_bc_matrix'
 	raw_h5 <- 'raw_feature_bc_matrix.h5'
@@ -118,7 +118,7 @@ if (sequencing_type == 'standard')
 
 if (sequencing_type == 'flex')
 {
-	cellranger_data = paste(soupX_input_path, 'count/', sep='')
+	cellranger_data = file.path(soupX_input_path, 'count')
 	raw_folder <- 'sample_raw_feature_bc_matrix'
 	filtered_folder <- 'sample_filtered_feature_bc_matrix'
 	raw_h5 <- 'sample_raw_feature_bc_matrix.h5'
@@ -176,17 +176,20 @@ soupify_outs <- function(in_path, out_path, cluster_folder_name) #, raw_folder=r
   dev.off()
 }
 
-if (data_type == 'outs')
-{
-  print('outs')
+# Check which file structure is present
+if (data_type == "outs") {
 
-  folder_name = 'graphclust'
-  if (sequencing_type == 'flex')
-  {
-     folder_name = 'gene_expression_graphclust'
+  graphclust_dir <- Filter(
+    function(d) dir.exists(file.path(cellranger_data, "analysis/clustering", d)),
+    c("gene_expression_graphclust", "graphclust")
+  )
+
+  if (length(graphclust_dir) == 0) {
+    all_files <- list.files(cellranger_data, recursive = TRUE, full.names = TRUE)
+    stop("No valid graphclust directory found. Files present:\n", paste(all_files, collapse = "\n"))
   }
 
-  soupify_outs(cellranger_data, soupX_output_path, folder_name)
+  soupify_outs(cellranger_data, soupX_output_path, graphclust_dir)
 }
 #--------------------------------------------------------------------
 

--- a/src/scripts/soupX.R
+++ b/src/scripts/soupX.R
@@ -75,13 +75,13 @@ contam_plot = function(sc)
   print(summary(post))
 
   p_contam <- ggplot(post, aes(x = x, y = y)) +
-    geom_line(color = '#440154FF', size = 1.2) +  # blue solid line
+    geom_line(color = '#440154FF', linewidth = 1.2) +
     geom_vline(xintercept = fit$rhoEst, color = '#26828EFF', size = 1, linetype = 'solid') +  # red estimate line
     stat_function(fun = function(x) 
     {
       dgamma(x, shape = (fit$priorRho / fit$priorRhoStdDev)^2, rate  = fit$priorRho / (fit$priorRhoStdDev^2))
     },
-    color = '#C0C0C0', linetype = 'dashed', size = 1) +  # gray dashed prior
+    color = '#C0C0C0', linetype = 'dashed', linewidth = 1) +
     labs(
       x = expression('Contamination Fraction ('*rho*')'),
       y = 'Posterior Density',

--- a/src/scripts/trajectory_analysis.R
+++ b/src/scripts/trajectory_analysis.R
@@ -81,7 +81,7 @@ suppressPackageStartupMessages(library(Seurat, lib.loc=lib_path))
 suppressPackageStartupMessages(library(SeuratWrappers, lib.loc=lib_path))
 suppressPackageStartupMessages(library(monocle3, lib.loc=lib_path))
 suppressPackageStartupMessages(library(ggplot2, lib.loc=lib_path))
-suppressPackageStartupMessages(library(qs, lib.loc=lib_path))
+suppressPackageStartupMessages(library(qs2, lib.loc=lib_path))
 # --------------------------------------------------------------------
 
 # DIRECTORIES
@@ -233,7 +233,7 @@ trajectory_analysis <- function(cds, cluster.scheme, partition.trajectory)
 }
 # --------------------------------------------------------------------
 
-# SAVE THE cell_Data_set OBJECT AS qs AND/OR rds
+# SAVE THE cell_Data_set OBJECT AS qs2 AND/OR rds
 # --------------------------------------------------------------------
 save_cds <- function(cds, final.storage)
 {
@@ -243,11 +243,11 @@ save_cds <- function(cds, final.storage)
 	{
 		print(s)
 
-		if (s == 'qs')
+		if (s == 'qs2')
 		{
-			print('You have requested a qs file...OK')
-			f_name = paste0(core_name, '.qs')
-			qsave(cds, f_name)
+			print('You have requested a qs2 file...OK')
+			f_name = paste0(core_name, '.qs2')
+			qs2::qs_save(cds, f_name)
 		}
 
 		if (s == 'rds')
@@ -263,16 +263,16 @@ save_cds <- function(cds, final.storage)
 
 # GET SEURAT OBJECT EXTENSION AND LOAD SEURAT OBJECT
 # --------------------------------------------------------------------
-# NEED to FIX THIS -- THIS WILL OPEN BOTH QS AND RDS FILES ERER 12.9.24
+# NEED to FIX THIS -- THIS WILL OPEN BOTH qs2 AND RDS FILES ERER 12.9.24
 print('Importing seurat object.')
 S <- ''
 
 extension = file_ext(seurat_object)
 
-if (extension == 'qs')
+if (extension == 'qs2')
 {
-	print('reading in qs file...')
-	S = qread(seurat_object)
+	print('reading in qs2 file...')
+	S = qs2::qs_read(seurat_object)
 }
 
 if (extension == 'rds')


### PR DESCRIPTION
The following changes have been made to allow for SWANS to execute on a slurm-managed HPC cluster.

- Main relevant issue:
    - #11 
- Additional issues addressed:
    - #21
    - #27
    - #22  

# Changes made to add HPC execution

- Added `EXECUTOR` as an option in `example_prelim_configs.yaml` and `example_post_annotation_configs.yaml`
- For `EXECUTOR` config, the permitted options are `slurm` and `local`, which will be parsed by cache scripts and `run_snakemake.sh`
- Added snakemake profiles for local (`profiles/local`) and slurm (`profiles/slurm`) execution (in `run_snakemake.sh`, `EXECUTOR` config will be used to determine which profile gets passed to snakemake)

## Instructions for cluster execution via slurm

In the `configs/example_post_annotation_configs.yaml` and `configs/example_post_annotation_configs.yaml`, set `EXECUTOR: slurm` to use the slurm profile for snakemake (located in `profiles/slurm/config.yaml`).

The slurm profile for snakemake may need to be adjusted for different HPC environments, dataset sizes, etc. The `profiles/slurm/config.yaml` file can be edited to specify resources to be requested when submitting jobs via slurm, both default and per rule. An example is provided for `cellranger_counts`. See Snakemake documentation for explanation of resource options.

# Additional changes

- Updated pond Docker image version (1.2 → 1.3) in Snakefile and FinalSnakefile
- Added `-r/--runtype` as an optional commandline option so that dry-run can be specified when running `run_snakemake.sh` (default: runs as normal, not dry-run) (very helpful for HPC, so dry-run can be run easily)
    - e.g., `bash run_snakemake.sh -r dry-run` will pass `dry-run` to prelim and final snakemake calls
- Changed storage for qs → qs2 to address #27 and #21
- Changed logging method so all outputs go to logfile. Otherwise, some R stderr/stdout will go to `.snakemake/slurm_logs` in cluster execution
- Changing method for getting graphclust_dir (use `Filter()` to detect dirname)
- Changing `plan(multisession(...))` to `plan(multicore, ...)` (works properly for cluster execution; not tested in local execution); adding `future.seed = TRUE`
- Setting memory to be `as.numeric()`; cannot be integer because memory value may exceed `2147483647` (R's `integer.max` size) in `create_images_DGE.R`, which should address #22 

# Testing results

The following results were run and completed successfully:

## `EXECUTOR: slurm`

**Preliminary analysis**

<details> 
<summary>prelim_configs.yaml</summary>

```yaml
# contact (email will be sent when jobs complete) 
contact: USER@chop.edu

# local execution (local) or cluster execution via slurm (slurm)?
EXECUTOR: slurm

# project name (IN LOWER CASE) base_name: (name of output directory under data/endpoints/)
PROJECT: project_test_slurm

# organism (e.g., mouse, human)
ORGANISM: human

# sequencing type 10X Genomics Standard/GEM or Flex (standard, flex)
SEQUENCING_TYPE: standard

# starting point data (e.g., fastq, cellranger, matrix)
STARTING_DATA: fastq

# run Cell Ranger count pipeline (y/n)
RUN_CELLRANGER: y

# path to the genome to use in cellranger
CELLRANGER_REFERENCE: reference_scRNA/cellranger/human/human_GRCh38-3.0.0/

# run multiQC on Cell Ranger output (y/n) -- must have outs/summary.html 
RUN_MULTIQC: y

# create bam file when running cellranger (slower) (y/n)
OUTPUT_BAM: n

# run SoupX (y/n)
RUN_SOUPX: y

# starting files for soupX: (outs, no_clusters, h5)
SOUPX_START: outs

# run doubletFinder (y/n)
RUN_DOUBLETFINDER: y

# mito cutoff (e.g., numeric value)
MITO: 15

# ribo cutoff (e.g., numeric value)
RIBO: 100 

# feature thresholds #
# e.g., S <- subset(S.merged, subset = nFeature_RNA > 200 & nFeature_RNA < 3000)
MIN_FEATURE_THRESHOLD: 200
MAX_FEATURE_THRESHOLD: 3000

# metadata by which to split the object into layers (Experiment, Sample)
SPLIT_LAYERS_BY: Sample

# number of PCs to use in Seurat (integer)
COMPONENTS: 30

# number of variable features (integer)
NUM_VARIABLE_FEATURES: 3000

# which features to use for scale data? (all or variable)
SCALE_DATA_FEATURES: variable

# should mito percent be regressed? (y/n)
MITO_REGRESSION: n

# should ribo percent be regressed? (y/n)
RIBO_REGRESSION: n

# file of genes to be regressed
REGRESSION_FILE:

# should cell cycle be regressed? (y/n)
CELL_CYCLE_REGRESSION: n

# which cell cycling method (standard, alternative)
CELL_CYCLE_METHOD: standard

# normalization method for Seurat (standard, sct)
SEURAT_NORMALIZATION_METHOD: standard,sct

# integration method for seurat (cca, rpca, harmony)
SEURAT_INTEGRATION_METHOD: cca,rpca,harmony

# resolution value(s) examples: single value: 0.5; multiple values: 0.1,0.3.0.5 
RESOLUTION: 0.1,0.2,0.3

# which FindClusters algorithm (1,2,3,4 --> 1 = original Louvain algorithm (default); 2 = Louvain algorithm with multilevel refinement; 3 = SLM algorithm; 4 = Leiden algorithm)
FIND_CLUSTERS_ALGORITHM: 

# run integration in reference-based fashion? (y/n)
REFERENCE_BASED_INTEGRATION: n

# which sample(s) to use as references for ref-based integration? (names from samples.sample_list)
REFERENCE_SAMPLES: 

# run Azimuth annotation in Seurat? (y/n)
RUN_AZIMUTH: n

# Azimuth reference dataset to use for annotation
# human ref options: adiposeref, bonemarrowref, fetusref, heartref, humancortexref, kidneyref, lungref, pancreasref, pbmcref, tonsilref
# mouse ref options:  mousecortexref
AZIMUTH_REFERENCE: 

# run TransferData in Seurat to annotate with a provided reference Seurat object? (y/n)
RUN_TRANSFERDATA: n

# path to reference Seurat object for TransferData? (path/to/seuratfile.storage)
TRANSFERDATA_REF_FILE: 

# which dimensional reduction in the TRANSFERDATA_REF_FILE to use for TransferData?
TRANSFERDATA_REDUCTION: 

# which Seurat meta.data column to use for TransferData annotation? 
TRANSFERDATA_ANNOCOL:

# make tsne plots (y/n)
TSNE: n

# run conserved genes (y/n) -- only run with multiple experiments
CONSERVED_GENES: n

# file is automatically saved as qs2 file.
# adding rds will create two files (rds + qs2)
# storage format (rds)
STORAGE: 

# number of threads
THREADS: 30

# max memory (write out fully in bytes, e.g., 1689064417920, NOT 1.89T)
MEMORY: 107374182400

# relative path with filename to file containing genes of interest (optional)
USER_GENE_FILE: 

# which visualization for USER_GENE_FILE (feature,violin,ridge,dot) -- choose 1, more, or leave blank
# (feature plotted by default) choosing all will create very large pdf file
VISUALIZATION: dot 



# DO NOT ALTER BELOW ##########################
# location of cellranger executable binaries
CELLRANGER: /usr/local/bin/cellranger

# location of multiqc executable
MULTIQC: /usr/local/bin/multiqc

# location of R library path
RPATH: /usr/local/lib/R/site-library/
# ###############################################
```
</details>
  
- [x] cellranger_counts
- [x] multiqc_cellranger_report
- [x] soupX
- [x] doubletFinder
- [x] create_initial_seurat
- [x] make_qc_report
- [x] memory
- [x] analyze_sc_object
- [x] cluster_plots_DGE

**Post-annotation analysis**

<details> 
<summary>post_annotation_configs.yaml</summary>

```yaml
# run finale (y/n)
RUN_FINAL_ANALYSIS: y

# local execution or cluster execution via slurm?
EXECUTOR: slurm

# minimimum % of cells in one of compared groups for dge
MIN_PCT: 0.1

# filtering DEGs (avg_log2FC) -- single value: e.g., 0.1 (longer) 2.5 (shorter)
# use 0 to keep all results (pathway analysis); non-zero (gene set enrichment analysis)
AVG_LOG2FC_THRESHOLD: 1.5

# filtering threshold/value of adj.p.value for pathway/gsea results -- single value: e.g., 0.05 
FINAL_FILTERING_THRESHOLD: 0.10

#### WHAT IF USER IS SUPPLYING OBJECT?????
# final normalization method for Seurat (standard, sct) -- choose only one
FINAL_SEURAT_NORMALIZATION_METHOD: sct

# final integration method for seurat (cca, rpca, harmony) -- choose only one
FINAL_SEURAT_INTEGRATION_METHOD: cca

# final resolution value -- single value: e.g., 0.5
FINAL_RESOLUTION: 0.1

# file with names of new clusters
CLUSTER_ANNOTATION_FILE: clusters.txt
# --------------------------------------------

# -- ADDITIONAL ANALYSIS ---------------------

# run Monocle3 trajectory analysis? (y/n) -- optional
RUN_TRAJECTORY_ANALYSIS: y

# partition clusters (y/n) 
# if y, CLUSTER_ANNOTATION_FILE needs a column called 'partition' with a value for each cluster
PARTITION_TRAJECTORY: y
# --------------------------------------------

# -- SUPPLYING SEURAT OBJECT ----------------

# supply final Seurat object (y/n)
PROVIDE_ANALYZED_SEURAT_OBJECT: n

# path to seurat object -- cannot be blank if PROVIDE_ANALYZED_SEURAT_OBJECT = 'y'
USER_ANALYZED_SEURAT_OBJECT: 

# meta data character string to access 'Sample' in seurat object (e.g., Samples, sample_name')
USER_ANALYZED_SEURAT_OBJECT_META_SAMPLE:

# meta data character string to access 'Experiment' in seurat object (e.g., Experiment, Conditions)
USER_ANALYZED_SEURAT_OBJECT_META_EXPERIMENT:

# meta data character string that holding annotation information in seurat object (e.g., celltypes, annotation_layer)
USER_ANALYZED_SEURAT_OBJECT_META_ANNOTATION:

# umap reduction in supplied seurat object (e.g., standard.cca.umap)
USER_UMAP_REDUCTION:

# tsne reduction in supplied seurat object (e.g., standard.rpca.tsne)
USER_TNSE_REDUCTION:

# use only if providing annotated ANALYZED_SEURAT_OBJECT
# annotate seurat object? (y/n)
ANNOTATE_PROVIDED_FINAL_SEURAT_OBJECT:
# --------------------------------------------

# final storage format (rds,sceo,cloupe,cellchat,cellphone)
FINAL_STORAGE: sceo,cloupe,cellchat,cellphone

# 10X end user license agreement 
# required if cloupe listed for FINAL_STORAGE (y/n)
EULA: y

# relative path with filename to file containing genes of interest
FINAL_USER_GENE_FILE: setup/e_mtab_13067/e_mtab_13067_genes.txt

# which visualization for FINAL_USER_GENE_FILE (feature,violin,ridge,dot) -- choose 1, more, or leave blank
# (feature plotted by default) choosing all will create very large pdf file
FINAL_VISUALIZATION: dot

# run conserved genes (y/n) -- only run with multiple experiments
FINAL_CONSERVED_GENES: n

# number of threads
FINAL_THREADS: 30
```
</details>
  
- [x] final_analysis
- [x] trajectory_analysis
- [x] final_report
- [x] benchmarks
- [x] bench_report

## `EXECUTOR: local`

**Preliminary analysis**

<details>
<summary>prelim_configs.yaml</summary>

```yaml
# contact (email will be sent when jobs complete) 
contact: USER@chop.edu

# local execution (local) or cluster execution via slurm (slurm)?
EXECUTOR: local

# project name (IN LOWER CASE) base_name: (name of output directory under data/endpoints/)
PROJECT: project_test_local

# organism (e.g., mouse, human)
ORGANISM: human

# sequencing type 10X Genomics Standard/GEM or Flex (standard, flex)
SEQUENCING_TYPE: standard

# starting point data (e.g., fastq, cellranger, matrix)
STARTING_DATA: fastq

# run Cell Ranger count pipeline (y/n)
RUN_CELLRANGER: y

# path to the genome to use in cellranger
CELLRANGER_REFERENCE: reference_scRNA/cellranger/human/human_GRCh38-3.0.0/

# run multiQC on Cell Ranger output (y/n) -- must have outs/summary.html 
RUN_MULTIQC: y

# create bam file when running cellranger (slower) (y/n)
OUTPUT_BAM: n

# run SoupX (y/n)
RUN_SOUPX: y

# starting files for soupX: (outs, no_clusters, h5)
SOUPX_START: outs

# run doubletFinder (y/n)
RUN_DOUBLETFINDER: y

# mito cutoff (e.g., numeric value)
MITO: 15

# ribo cutoff (e.g., numeric value)
RIBO: 100 

# feature thresholds #
# e.g., S <- subset(S.merged, subset = nFeature_RNA > 200 & nFeature_RNA < 3000)
MIN_FEATURE_THRESHOLD: 200
MAX_FEATURE_THRESHOLD: 3000

# metadata by which to split the object into layers (Experiment, Sample)
SPLIT_LAYERS_BY: Sample

# number of PCs to use in Seurat (integer)
COMPONENTS: 30

# number of variable features (integer)
NUM_VARIABLE_FEATURES: 3000

# which features to use for scale data? (all or variable)
SCALE_DATA_FEATURES: variable

# should mito percent be regressed? (y/n)
MITO_REGRESSION: n

# should ribo percent be regressed? (y/n)
RIBO_REGRESSION: n

# file of genes to be regressed
REGRESSION_FILE:

# should cell cycle be regressed? (y/n)
CELL_CYCLE_REGRESSION: n

# which cell cycling method (standard, alternative)
CELL_CYCLE_METHOD: standard

# normalization method for Seurat (standard, sct)
SEURAT_NORMALIZATION_METHOD: standard,sct

# integration method for seurat (cca, rpca, harmony)
SEURAT_INTEGRATION_METHOD: cca,rpca,harmony

# resolution value(s) examples: single value: 0.5; multiple values: 0.1,0.3.0.5 
RESOLUTION: 0.1,0.2,0.3

# which FindClusters algorithm (1,2,3,4 --> 1 = original Louvain algorithm (default); 2 = Louvain algorithm with multilevel refinement; 3 = SLM algorithm; 4 = Leiden algorithm)
FIND_CLUSTERS_ALGORITHM: 

# run integration in reference-based fashion? (y/n)
REFERENCE_BASED_INTEGRATION: n

# which sample(s) to use as references for ref-based integration? (names from samples.sample_list)
REFERENCE_SAMPLES: 

# run Azimuth annotation in Seurat? (y/n)
RUN_AZIMUTH: n

# Azimuth reference dataset to use for annotation
# human ref options: adiposeref, bonemarrowref, fetusref, heartref, humancortexref, kidneyref, lungref, pancreasref, pbmcref, tonsilref
# mouse ref options:  mousecortexref
AZIMUTH_REFERENCE: 

# run TransferData in Seurat to annotate with a provided reference Seurat object? (y/n)
RUN_TRANSFERDATA: n

# path to reference Seurat object for TransferData? (path/to/seuratfile.storage)
TRANSFERDATA_REF_FILE: 

# which dimensional reduction in the TRANSFERDATA_REF_FILE to use for TransferData?
TRANSFERDATA_REDUCTION: 

# which Seurat meta.data column to use for TransferData annotation? 
TRANSFERDATA_ANNOCOL:

# make tsne plots (y/n)
TSNE: n

# run conserved genes (y/n) -- only run with multiple experiments
CONSERVED_GENES: n

# file is automatically saved as qs2 file.
# adding rds will create two files (rds + qs2)
# storage format (rds)
STORAGE: 

# number of threads
THREADS: 30

# max memory (write out fully in bytes, e.g., 1689064417920, NOT 1.89T)
MEMORY: 107374182400

# relative path with filename to file containing genes of interest (optional)
USER_GENE_FILE: 

# which visualization for USER_GENE_FILE (feature,violin,ridge,dot) -- choose 1, more, or leave blank
# (feature plotted by default) choosing all will create very large pdf file
VISUALIZATION: dot 

# DO NOT ALTER BELOW ##########################
# location of cellranger executable binaries
CELLRANGER: /usr/local/bin/cellranger

# location of multiqc executable
MULTIQC: /usr/local/bin/multiqc

# location of R library path
RPATH: /usr/local/lib/R/site-library/
# ###############################################
```
</details>

- [x] cellranger_counts
- [x] multiqc_cellranger_report
- [x] soupX
- [x] doubletFinder
- [x] create_initial_seurat
- [x] make_qc_report
- [x] memory
- [x] analyze_sc_object
- [x] cluster_plots_DGE

**Post-annotation analysis**

<details> 
<summary>post_annotation_configs.yaml</summary>

```yaml
# run finale (y/n)
RUN_FINAL_ANALYSIS: y

# local execution or cluster execution via slurm?
EXECUTOR: local

# minimimum % of cells in one of compared groups for dge
MIN_PCT: 0.1

# filtering DEGs (avg_log2FC) -- single value: e.g., 0.1 (longer) 2.5 (shorter)
# use 0 to keep all results (pathway analysis); non-zero (gene set enrichment analysis)
AVG_LOG2FC_THRESHOLD: 1.5

# filtering threshold/value of adj.p.value for pathway/gsea results -- single value: e.g., 0.05 
FINAL_FILTERING_THRESHOLD: 0.10

#### WHAT IF USER IS SUPPLYING OBJECT?????
# final normalization method for Seurat (standard, sct) -- choose only one
FINAL_SEURAT_NORMALIZATION_METHOD: sct

# final integration method for seurat (cca, rpca, harmony) -- choose only one
FINAL_SEURAT_INTEGRATION_METHOD: cca

# final resolution value -- single value: e.g., 0.5
FINAL_RESOLUTION: 0.1

# file with names of new clusters
CLUSTER_ANNOTATION_FILE: clusters.txt
# --------------------------------------------

# -- ADDITIONAL ANALYSIS ---------------------

# run Monocle3 trajectory analysis? (y/n) -- optional
RUN_TRAJECTORY_ANALYSIS: y

# partition clusters (y/n) 
# if y, CLUSTER_ANNOTATION_FILE needs a column called 'partition' with a value for each cluster
PARTITION_TRAJECTORY: y
# --------------------------------------------

# -- SUPPLYING SEURAT OBJECT ----------------

# supply final Seurat object (y/n)
PROVIDE_ANALYZED_SEURAT_OBJECT: n

# path to seurat object -- cannot be blank if PROVIDE_ANALYZED_SEURAT_OBJECT = 'y'
USER_ANALYZED_SEURAT_OBJECT: 

# meta data character string to access 'Sample' in seurat object (e.g., Samples, sample_name')
USER_ANALYZED_SEURAT_OBJECT_META_SAMPLE:

# meta data character string to access 'Experiment' in seurat object (e.g., Experiment, Conditions)
USER_ANALYZED_SEURAT_OBJECT_META_EXPERIMENT:

# meta data character string that holding annotation information in seurat object (e.g., celltypes, annotation_layer)
USER_ANALYZED_SEURAT_OBJECT_META_ANNOTATION:

# umap reduction in supplied seurat object (e.g., standard.cca.umap)
USER_UMAP_REDUCTION:

# tsne reduction in supplied seurat object (e.g., standard.rpca.tsne)
USER_TNSE_REDUCTION:

# use only if providing annotated ANALYZED_SEURAT_OBJECT
# annotate seurat object? (y/n)
ANNOTATE_PROVIDED_FINAL_SEURAT_OBJECT:
# --------------------------------------------

# final storage format (rds,sceo,cloupe,cellchat,cellphone)
FINAL_STORAGE: sceo,cloupe,cellchat,cellphone

# 10X end user license agreement 
# required if cloupe listed for FINAL_STORAGE (y/n)
EULA: y

# relative path with filename to file containing genes of interest
FINAL_USER_GENE_FILE: setup/e_mtab_13067/e_mtab_13067_genes.txt

# which visualization for FINAL_USER_GENE_FILE (feature,violin,ridge,dot) -- choose 1, more, or leave blank
# (feature plotted by default) choosing all will create very large pdf file
FINAL_VISUALIZATION: dot

# run conserved genes (y/n) -- only run with multiple experiments
FINAL_CONSERVED_GENES: n

# number of threads
FINAL_THREADS: 30
```
</details>

- [x] final_analysis
- [x] trajectory_analysis
- [x] final_report
- [x] benchmarks
- [x] bench_report
